### PR TITLE
Fix employee payment method documentation

### DIFF
--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -3570,11 +3570,11 @@ paths:
                         type: string
                         description: The bank account name
                       priority:
-                        type: string
-                        description: 'The order of priority for each payment split, with "1" being the first bank account paid. Priority must be unique and sequential.'
+                        description: 'The order of priority for each payment split, with priority 1 being the first bank account paid. Priority must be unique and sequential.'
+                        type: integer
                       split_amount:
-                        type: string
-                        description: The amount allocated for each payment split
+                        description: The cents amount allocated for each payment split
+                        type: integer
               required:
                 - version
                 - type
@@ -3587,15 +3587,15 @@ paths:
                   splits:
                     - uuid: e88f9436-b74e-49a8-87e9-777b9bfe715e
                       name: BoA Checking Account
-                      priority: '1'
-                      split_amount: '500'
+                      priority: 1
+                      split_amount: 500
                     - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
                       name: Chase Checking Account
-                      priority: '2'
-                      split_amount: '1000'
+                      priority: 2
+                      split_amount: 1000
                     - uuid: 1531e824-8d9e-4bd8-9f90-0d04608125d7
                       name: US Bank Checking Account
-                      priority: '3'
+                      priority: 3
                       split_amount: nil
               example-2:
                 value:
@@ -3605,12 +3605,12 @@ paths:
                   splits:
                     - uuid: e88f9436-b74e-49a8-87e9-777b9bfe715e
                       name: BoA Checking Account
-                      priority: '1'
-                      split_amount: '60'
+                      priority: 1
+                      split_amount: 60
                     - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
                       name: Chase Checking Account
-                      priority: '2'
-                      split_amount: '40'
+                      priority: 2
+                      split_amount: 40
               example-3:
                 value:
                   version: 63859768485e218ccf8a449bb60f14ed
@@ -5962,31 +5962,15 @@ components:
             splits:
               - uuid: e88f9436-b74e-49a8-87e9-777b9bfe715e
                 name: BoA Checking Account
-                priority: '1'
-                split_amount: '500'
-<<<<<<< HEAD
-<<<<<<< HEAD
+                priority: 1
+                split_amount: 500
               - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
                 name: Chase Checking Account
-                priority: '2'
-                split_amount: '1000'
+                priority: 2
+                split_amount: 1000
               - uuid: 1531e824-8d9e-4bd8-9f90-0d04608125d7
-=======
-              - id: 0d2b7f73-05d6-4184-911d-269edeecc30a
-                name: Chase Checking Account
-                priority: '2'
-                split_amount: '1000'
-              - id: 1531e824-8d9e-4bd8-9f90-0d04608125d7
->>>>>>> 0c4842a (Change amount to split_amount)
-=======
-              - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
-                name: Chase Checking Account
-                priority: '2'
-                split_amount: '1000'
-              - uuid: 1531e824-8d9e-4bd8-9f90-0d04608125d7
->>>>>>> 6d1f467 (Update descriptions, fix minor nits/naming issues)
                 name: US Bank Checking Account
-                priority: '3'
+                priority: 3
                 split_amount: nil
         Example-2:
           value:
@@ -5996,12 +5980,12 @@ components:
             splits:
               - uuid: e88f9436-b74e-49a8-87e9-777b9bfe715e
                 name: BoA Checking Account
-                priority: '1'
-                split_amount: '100'
+                priority: 1
+                split_amount: 60
               - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
                 name: Chase Checking Account
-                priority: '2'
-                split_amount: '0'
+                priority: 2
+                split_amount: 40
         Example-3:
           value:
             version: 63859768485e218ccf8a449bb60f14ed
@@ -6035,11 +6019,11 @@ components:
                 type: string
                 description: The bank account name
               priority:
-                type: string
-                description: 'The order of priority for each payment split, with "1" being the first bank account paid. Priority must be unique and sequential.'
+                type: integer
+                description: 'The order of priority for each payment split, with priority 1 being the first bank account paid. Priority must be unique and sequential.'
               split_amount:
-                type: string
-                description: The amount allocated for each payment split
+                type: integer
+                description: The cents amount allocated for each payment split
       required:
         - version
         - type

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -5952,11 +5952,19 @@ components:
                 name: BoA Checking Account
                 priority: '1'
                 split_amount: '500'
+<<<<<<< HEAD
               - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
                 name: Chase Checking Account
                 priority: '2'
                 split_amount: '1000'
               - uuid: 1531e824-8d9e-4bd8-9f90-0d04608125d7
+=======
+              - id: 0d2b7f73-05d6-4184-911d-269edeecc30a
+                name: Chase Checking Account
+                priority: '2'
+                split_amount: '1000'
+              - id: 1531e824-8d9e-4bd8-9f90-0d04608125d7
+>>>>>>> 0c4842a (Change amount to split_amount)
                 name: US Bank Checking Account
                 priority: '3'
                 split_amount: nil

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -1575,6 +1575,8 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
+      tags:
+        - Benefits
     post:
       summary: Create a company benefit
       tags:
@@ -3540,6 +3542,9 @@ paths:
             schema:
               type: object
               properties:
+                version:
+                  type: string
+                  description: The current version of the object. See the versioning guide for information on how to use this field.
                 type:
                   type: string
                   enum:
@@ -3571,10 +3576,12 @@ paths:
                         type: string
                         description: The amount allocated for each payment split
               required:
+                - version
                 - type
             examples:
               example-1:
                 value:
+                  version: 63859768485e218ccf8a449bb60f14ed
                   type: Direct Deposit
                   split_by: Amount
                   splits:
@@ -3592,6 +3599,7 @@ paths:
                       split_amount: nil
               example-2:
                 value:
+                  version: 63859768485e218ccf8a449bb60f14ed
                   type: Direct Deposit
                   split_by: Percentage
                   splits:
@@ -3605,8 +3613,11 @@ paths:
                       split_amount: '40'
               example-3:
                 value:
+                  version: 63859768485e218ccf8a449bb60f14ed
                   type: Check
         description: ''
+      tags:
+        - Employee Bank Accounts (Beta)
 components:
   schemas:
     Employee:
@@ -5945,6 +5956,7 @@ components:
       x-examples:
         Example-1:
           value:
+            version: 63859768485e218ccf8a449bb60f14ed
             type: Direct Deposit
             split_by: Amount
             splits:
@@ -5978,6 +5990,7 @@ components:
                 split_amount: nil
         Example-2:
           value:
+            version: 63859768485e218ccf8a449bb60f14ed
             type: Direct Deposit
             split_by: Percentage
             splits:
@@ -5991,8 +6004,13 @@ components:
                 split_amount: '0'
         Example-3:
           value:
+            version: 63859768485e218ccf8a449bb60f14ed
             type: Check
+      description: ''
       properties:
+        version:
+          type: string
+          description: The current version of the object. See the versioning guide for information on how to use this field.
         type:
           type: string
           enum:
@@ -6023,8 +6041,8 @@ components:
                 type: string
                 description: The amount allocated for each payment split
       required:
+        - version
         - type
-      description: ''
   securitySchemes:
     Authorization:
       type: http

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -5953,6 +5953,7 @@ components:
                 priority: '1'
                 split_amount: '500'
 <<<<<<< HEAD
+<<<<<<< HEAD
               - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
                 name: Chase Checking Account
                 priority: '2'
@@ -5965,6 +5966,13 @@ components:
                 split_amount: '1000'
               - id: 1531e824-8d9e-4bd8-9f90-0d04608125d7
 >>>>>>> 0c4842a (Change amount to split_amount)
+=======
+              - uuid: 0d2b7f73-05d6-4184-911d-269edeecc30a
+                name: Chase Checking Account
+                priority: '2'
+                split_amount: '1000'
+              - uuid: 1531e824-8d9e-4bd8-9f90-0d04608125d7
+>>>>>>> 6d1f467 (Update descriptions, fix minor nits/naming issues)
                 name: US Bank Checking Account
                 priority: '3'
                 split_amount: nil


### PR DESCRIPTION
Changes: 
- change split_amount and priority from string to integer 
- update description of split_amount to specify that it's a cents amount
- update examples