### PR TITLE
Remove duplicate "tags:" keys

### DIFF
--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -1575,8 +1575,6 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
-      tags:
-        - Benefits
     post:
       summary: Create a company benefit
       tags:
@@ -3618,8 +3616,6 @@ paths:
                   version: 63859768485e218ccf8a449bb60f14ed
                   type: Check
         description: ''
-      tags:
-        - Employee Bank Accounts (Beta)
 components:
   schemas:
     Employee:


### PR DESCRIPTION
I came across two duplicate `tags:` keys in the yaml spec when trying to generate HTML documentation using [Redoc CLI](https://redoc.ly/docs/redoc/quickstart/cli/). Removing these two duplicates allowed me to generate the documentation successfully.