### PR TITLE
401k tiered and elective API doc updates - feedback

### DIFF
--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -13,15 +13,18 @@ tags:
   - name: Employee Bank Accounts (Beta)
   - name: Employee Payment Method (Beta)
   - name: Employees
+  - name: Federal Tax Details (Beta)
+  - name: Flows (Beta)
+  - name: Forms (Beta)
   - name: Garnishments
   - name: Job Applicants (Beta)
   - name: Jobs
   - name: Locations
   - name: Pay Schedules
   - name: Payroll
+  - name: Signatories (Beta)
   - name: Terminations
   - name: Time Off Requests
-  - name: Federal Tax Details (Beta)
 info:
   title: Gusto API
   version: '1.0'
@@ -40,7 +43,10 @@ paths:
     get:
       summary: Get an employee
       operationId: get-v1-employees
-      description: Get an employee.
+      description: |
+        Get an employee.
+
+        `scope: employees.read`
       parameters:
         - in: query
           name: include
@@ -59,7 +65,10 @@ paths:
     put:
       summary: Update an employee
       operationId: put-v1-employees
-      description: Update an employee.
+      description: |-
+        Update an employee.
+
+        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -117,7 +126,10 @@ paths:
     get:
       summary: Get a company
       operationId: get-v1-companies
-      description: Get a company.
+      description: |-
+        Get a company.
+
+        `scope: companies.read`
       parameters: []
       responses:
         '200':
@@ -159,7 +171,10 @@ paths:
                 - custom_fields
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/perParam'
-      description: 'Get all of the employees, onboarding, active and terminated, for a given company.'
+      description: |-
+        Get all of the employees, onboarding, active and terminated, for a given company.
+
+        `scope: employees.read`
       responses:
         '200':
           $ref: '#/components/responses/Employee-List'
@@ -205,7 +220,10 @@ paths:
                   ssn: '123456294'
         description: Create an employee.
       parameters: []
-      description: Create an employee.
+      description: |-
+        Create an employee.
+
+        `scope: employees.write`
       responses:
         '201':
           $ref: '#/components/responses/Employee-Object'
@@ -226,7 +244,10 @@ paths:
           $ref: '#/components/responses/Job-Object'
       operationId: get-v1-jobs-job_id
       parameters: []
-      description: Get a job.
+      description: |-
+        Get a job.
+
+        `scope: jobs.read`
       tags:
         - Jobs
     put:
@@ -235,7 +256,10 @@ paths:
         '200':
           $ref: '#/components/responses/Job-Object'
       operationId: put-v1-jobs-job_id
-      description: Update a job.
+      description: |-
+        Update a job.
+
+        `scope: jobs.write`
       parameters: []
       requestBody:
         content:
@@ -273,7 +297,10 @@ paths:
         '204':
           description: No Content
       operationId: delete-v1-jobs-job_id
-      description: Deletes a specific job that an employee holds.
+      description: |-
+        Deletes a specific job that an employee holds.
+
+        `scope: jobs.write`
   '/v1/employees/{employee_id}/jobs':
     parameters:
       - schema:
@@ -291,7 +318,10 @@ paths:
         '200':
           $ref: '#/components/responses/Job-List'
       operationId: get-v1-employees-employee_id-jobs
-      description: Get all of the jobs that an employee holds.
+      description: |-
+        Get all of the jobs that an employee holds.
+
+        `scope: jobs.read`
       tags:
         - Jobs
     post:
@@ -300,7 +330,10 @@ paths:
         '201':
           $ref: '#/components/responses/Job-Object'
       operationId: post-v1-jobs-job_id
-      description: Create a job.
+      description: |-
+        Create a job.
+
+        `scope: jobs.write`
       parameters: []
       requestBody:
         content:
@@ -345,6 +378,8 @@ paths:
         Company locations represent all addresses associated with a company. These can be filing addesses, mailing addresses, and/or work locations; one address may serve multiple, or all, purposes.
 
         Since all company locations are subsets of locations, retrieving or updating an individual record should be done via the locations endpoints.
+
+        `scope: companies.read`
       tags:
         - Locations
     post:
@@ -357,6 +392,8 @@ paths:
         Company locations represent all addresses associated with a company. These can be filing addesses, mailing addresses, and/or work locations; one address may serve multiple, or all, purposes.
 
         Since all company locations are subsets of locations, retrieving or updating an individual record should be done via the locations endpoints.
+
+        scope: companies.write
       parameters: []
       requestBody:
         content:
@@ -466,7 +503,10 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: get-v1-locations-location_id
-      description: Get a location.
+      description: |-
+        Get a location.
+
+        `scope: companies.read`
       parameters: []
       tags:
         - Locations
@@ -476,7 +516,10 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: put-v1-locations-location_id
-      description: Update a location.
+      description: |-
+        Update a location.
+
+        scope: companies.write
       requestBody:
         content:
           application/json:
@@ -535,7 +578,10 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Object'
       operationId: get-v1-contractors-contractor_id
-      description: Get a contractor.
+      description: |-
+        Get a contractor.
+
+        `scope: employees.read`
     put:
       summary: Update a contractor
       tags:
@@ -544,7 +590,10 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Object'
       operationId: put-v1-contractors-contractor_id
-      description: Update a contractor.
+      description: |-
+        Update a contractor.
+
+        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -623,7 +672,10 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-List'
       operationId: get-v1-companies-company_id-contractors
-      description: 'Get all contractors, active and inactive, individual and business, for a company.'
+      description: |-
+        Get all contractors, active and inactive, individual and business, for a company.
+
+        `scope: employees.read`
     post:
       summary: Create a contractor
       tags:
@@ -632,7 +684,10 @@ paths:
         '201':
           $ref: '#/components/responses/Contractor-Object'
       operationId: post-v1-companies-company_id-contractors
-      description: Create an individual or business contractor.
+      description: |-
+        Create an individual or business contractor.
+
+        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -717,7 +772,10 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Payments'
       operationId: get-v1-companies-company_id-contractor_payments
-      description: 'Returns an object containing individual contractor payments, within a given time period, including totals.'
+      description: |-
+        Returns an object containing individual contractor payments, within a given time period, including totals.
+
+        `scope: payrolls.read`
       parameters:
         - schema:
             type: string
@@ -808,7 +866,10 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Payment-Object'
       operationId: get-v1-companies-company_id-contractor_payment-contractor-payment
-      description: Returns a single contractor payments
+      description: |-
+        Returns a single contractor payments
+
+        `scope: payrolls.read`
     delete:
       summary: Cancel a contractor payment (Beta)
       tags:
@@ -840,6 +901,8 @@ paths:
         Compensations contain information on how much is paid out for a job. Jobs may have many compensations, but only one that is active. The current compensation is the one with the most recent `effective_date`.
 
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error.
+
+        `scope: jobs.read`
       tags:
         - Compensations
     put:
@@ -854,6 +917,8 @@ paths:
         Compensations contain information on how much is paid out for a job. Jobs may have many compensations, but only one that is active. The current compensation is the one with the most recent `effective_date`.
 
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error
+
+        `scope: jobs.write`
       requestBody:
         content:
           application/json:
@@ -920,6 +985,8 @@ paths:
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error.
 
         Use the `flsa_status` to determine if an employee is elibgle for overtime.
+
+        `scope: jobs.read`
       tags:
         - Compensations
     post:
@@ -931,6 +998,8 @@ paths:
         Compensations contain information on how much is paid out for a job. Jobs may have many compensations, but only one that is active. The current compensation is the one with the most recent `effective_date`.
 
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error
+
+        `scope: jobs.write`
       responses:
         '201':
           $ref: '#/components/responses/Compensation-Object'
@@ -997,7 +1066,10 @@ paths:
         '200':
           $ref: '#/components/responses/Garnishment-List'
       operationId: get-v1-employees-employee_id-garnishments
-      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
+      description: |-
+        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
+
+        `scope: employees.read`
     post:
       summary: Create a garnishment
       tags:
@@ -1006,7 +1078,10 @@ paths:
         '201':
           $ref: '#/components/responses/Garnishment-Object'
       operationId: post-v1-employees-employee_id-garnishments
-      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
+      description: |-
+        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
+
+        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -1088,7 +1163,10 @@ paths:
         '200':
           $ref: '#/components/responses/Garnishment-Object'
       operationId: get-v1-garnishments-garnishment_id
-      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
+      description: |-
+        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
+
+        `scope: employees.read`
     put:
       summary: Update a garnishment
       tags:
@@ -1097,7 +1175,10 @@ paths:
         '200':
           $ref: '#/components/responses/Garnishment-Object'
       operationId: put-v1-garnishments-garnishment_id
-      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
+      description: |-
+        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
+
+        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -1180,6 +1261,8 @@ paths:
         Terminations are created whenever an employee is scheduled to leave the company. The only things required are an effective date (their last day of work) and whether they should receive their wages in a one-off termination payroll or with the rest of the company.
 
         Note that some states require employees to receive their final wages within 24 hours (unless they consent otherwise,) in which case running a one-off payroll may be the only option.
+
+        `scope: employees.read`
     post:
       summary: Create an employee termination
       tags:
@@ -1192,6 +1275,8 @@ paths:
         Terminations are created whenever an employee is scheduled to leave the company. The only things required are an effective date (their last day of work) and whether they should receive their wages in a one-off termination payroll or with the rest of the company.
 
         Note that some states require employees to receive their final wages within 24 hours (unless they consent otherwise,) in which case running a one-off payroll may be the only option.
+
+        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -1226,7 +1311,7 @@ paths:
         '200':
           $ref: '#/components/responses/Time-Off-Request-List'
       operationId: get-v1-companies-company_id-time_off_requests
-      description: |
+      description: |-
         Get all time off requests, past and present, for a company.
 
         In order to reduce the number of time off requests returned in a single response, or to retrieve time off requests from a time period of interest, you may use the `start_date` and `end_date` parameters.
@@ -1244,6 +1329,8 @@ paths:
         `?start_date='2019-05-01'&end_date='2019-08-31'`
 
         Returns all time off requests where the request start date is equal to or after May 1, 2019 and the request end date is equal to or before August 31, 2019.
+
+        `scope: time_off_requests.read`
       parameters:
         - schema:
             type: string
@@ -1318,7 +1405,10 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: get-v1-employees-employee_id-home_address
-      description: The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
+      description: |-
+        The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
+
+        `scope: employees.read`
     put:
       summary: Update an employee's home address
       tags:
@@ -1327,7 +1417,10 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: put-v1-employees-employee_id-home_address
-      description: The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
+      description: |-
+        The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
+
+        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -1377,7 +1470,10 @@ paths:
         '200':
           $ref: '#/components/responses/Pay-Schedule-List'
       operationId: get-v1-companies-company_id-pay_schedules
-      description: The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
+      description: |-
+        The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
+
+        `scope: payrolls.read`
       tags:
         - Pay Schedules
     post:
@@ -1459,7 +1555,10 @@ paths:
         '200':
           $ref: '#/components/responses/Pay-Schedule-Object'
       operationId: get-v1-companies-company_id-pay_schedules-pay_schedule_id
-      description: The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
+      description: |-
+        The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
+
+        `scope: payrolls.read`
       tags:
         - Pay Schedules
     put:
@@ -1586,7 +1685,20 @@ paths:
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
-        Verify a company bank account by confirming the two micro-deposits sent to the bank account. Note that the order of the two deposits specified in request parameters does not matter.
+        Verify a company bank account by confirming the two micro-deposits sent to the bank account. Note that the order of the two deposits specified in request parameters does not matter. There's a maximum of 5 verification attempts, after which we will automatically initiate a new set of micro-deposits and require the bank account to be verified with the new micro-deposits.
+
+        ### Bank account verification in demo
+
+        We provide the endpoint `POST '/v1/companies/{company_id_or_uuid}/bank_accounts/{bank_account_uuid}/send_test_deposits'` to facilitate bank account verification in the demo environment. This endpoint simulates the micro-deposits transfer and returns them in the reponse. You can call this endpoint as many times as you wish to retrieve the values of the two micro deposits.
+
+        ```
+          POST '/v1/companies/89771af8-b964-472e-8064-554dfbcb56d9/bank_accounts/ade55e57-4800-4059-9ecd-fa29cfeb6dd2/send_test_deposits'
+
+          {
+            "deposit_1": 0.02,
+            "deposit_2": 0.42
+          }
+        ```
       requestBody:
         content:
           application/json:
@@ -1618,6 +1730,8 @@ paths:
         Returns all benefits supported by Gusto.
 
         The benefit object in Gusto contains high level information about a particular benefit type and its tax considerations. When companies choose to offer a benefit, they are creating a Company Benefit object associated with a particular benefit.
+
+        `scope: benefits.read`
       tags:
         - Benefits
   '/v1/benefits/{benefit_id}':
@@ -1635,6 +1749,8 @@ paths:
         Returns a benefit supported by Gusto.
 
         The benefit object in Gusto contains high level information about a particular benefit type and its tax considerations. When companies choose to offer a benefit, they are creating a Company Benefit object associated with a particular benefit.
+
+        `scope: benefits.read`
       tags:
         - Benefits
       responses:
@@ -1660,6 +1776,8 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
+
+        `scope: company_benefits.read`
     post:
       summary: Create a company benefit
       tags:
@@ -1672,6 +1790,8 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
+
+        `scope: company_benefits.write`
       requestBody:
         content:
           application/json:
@@ -1718,6 +1838,8 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
+
+        `scope: company_benefits.read`
     put:
       summary: Update a company benefit
       tags:
@@ -1730,6 +1852,8 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
+
+        `scope: company_benefits:write`
       requestBody:
         content:
           application/json:
@@ -1778,6 +1902,8 @@ paths:
 
         #### Custom Earning Type
         Custom earning types are all the other earning types added specifically for a company.
+
+        `scope: payrolls.read`
     post:
       summary: Create a custom earning type
       tags:
@@ -1790,6 +1916,8 @@ paths:
         Create a custom earning type.
 
         If an inactive earning type exists with the same name, this will reactivate it instead of creating a new one.
+
+        `scope: payrolls:write`
       requestBody:
         content:
           application/json:
@@ -1827,7 +1955,10 @@ paths:
         '200':
           $ref: '#/components/responses/Earning-Type-Object'
       operationId: put-v1-companies-company_id-earning_types-earning_type_uuid
-      description: Update an earning type.
+      description: |-
+        Update an earning type.
+
+        `scope: payrolls.write`
       requestBody:
         content:
           application/json:
@@ -1849,7 +1980,10 @@ paths:
         '204':
           description: No Content
       operationId: delete-v1-companies-company_id-earning_types-earning_type_uuid
-      description: Deactivate an earning type.
+      description: |-
+        Deactivate an earning type.
+
+        `scope: payrolls.write`
   '/v1/employees/{employee_id}/employee_benefits':
     parameters:
       - schema:
@@ -1873,6 +2007,8 @@ paths:
         Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
 
         Returns an array of all employee benefits for this employee
+
+        `scope: employee_benefits.read`
     post:
       summary: Create an employee benefit
       tags:
@@ -1881,7 +2017,10 @@ paths:
         '201':
           $ref: '#/components/responses/Employee-Benefit-Object'
       operationId: post-v1-employees-employee_id-employee_benefits
-      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+      description: |-
+        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+
+        `scope: employee_benefits.write`
       requestBody:
         content:
           application/json:
@@ -7725,31 +7864,32 @@ components:
                   type: amount
                   value: '100.00'
             Tiered example:
-              id: 0
-              version: string
-              employee_id: 0
-              company_benefit_id: 0
-              active: true
-              employee_deduction: '0.00'
-              deduct_as_percentage: false
-              employee_deduction_annual_maximum: string
-              contribution:
-                type: tiered
-                value:
-                  tiers:
-                    - rate: '5.0'
-                      threshold: '2.0'
-                      threshold_delta: '2.0'
-                    - rate: '3.0'
-                      threshold: '5.0'
-                      threshold_delta: '3.0'
-              elective: false
-              company_contribution_annual_maximum: string
-              limit_option: string
-              catch_up: false
-              coverage_amount: string
-              deduction_reduces_taxable_income: unset
-              coverage_salary_multiplier: '0.00'
+              value:
+                id: 0
+                version: string
+                employee_id: 0
+                company_benefit_id: 0
+                active: true
+                employee_deduction: '0.00'
+                deduct_as_percentage: false
+                employee_deduction_annual_maximum: string
+                contribution:
+                  type: tiered
+                  value:
+                    tiers:
+                      - rate: '5.0'
+                        threshold: '2.0'
+                        threshold_delta: '2.0'
+                      - rate: '3.0'
+                        threshold: '5.0'
+                        threshold_delta: '3.0'
+                elective: false
+                company_contribution_annual_maximum: string
+                limit_option: string
+                catch_up: false
+                coverage_amount: string
+                deduction_reduces_taxable_income: unset
+                coverage_salary_multiplier: '0.00'
     Employee-Benefit-List:
       description: Example response
       content:

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -2057,11 +2057,15 @@ paths:
                       description: |-
                         The company contribution scheme.
 
-                        "amount": The company contributes a fixed amount per payroll. If elective is true, the contribution is matching, dollar-for-dollar.
+                        `amount`: The company contributes a fixed amount per payroll. If elective is true, the contribution is matching, dollar-for-dollar.
 
-                        "percentage": The company contributes a percentage of the payroll amount per payroll period. If elective is true, the contribution is matching, dollar-for-dollar.
+                        `percentage`: The company contributes a percentage of the payroll amount per payroll period. If elective is true, the contribution is matching, dollar-for-dollar.
 
-                        "tiered": The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching scheme.
+                        `tiered`: The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching scheme.
+                      enum:
+                        - tiered
+                        - percentage
+                        - amount
                     value:
                       description: |-
                         For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
@@ -2069,7 +2073,6 @@ paths:
                         For "tiered" contribution types, an array of tiers.
                       oneOf:
                         - type: string
-                          properties: {}
                           description: 'For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.'
                         - type: array
                           description: 'For "tiered" contribution types, an array of tiers.'
@@ -2090,7 +2093,7 @@ paths:
                                   If this is the first tier, a value of "5" means the company contribution will match employee deductions from 0% up to and including 5% of payroll.
                 elective:
                   type: boolean
-                  description: Whether the company contribution is elective (aka "matching"). For "tiered" contribution types this is ignored and assumed to be true.
+                  description: 'Whether the company contribution is elective (aka "matching"). For `tiered`, `elective_amount`, and `elective_percentage` contribution types this is ignored and assumed to be `true`.'
                   default: false
                 company_contribution_annual_maximum:
                   type: string
@@ -2232,11 +2235,15 @@ paths:
                       description: |-
                         The company contribution scheme.
 
-                        "amount": The company contributes a fixed amount per payroll. If elective is true, the contribution is matching, dollar-for-dollar.
+                        `amount`: The company contributes a fixed amount per payroll. If elective is true, the contribution is matching, dollar-for-dollar.
 
-                        "percentage": The company contributes a percentage of the payroll amount per payroll period. If elective is true, the contribution is matching, dollar-for-dollar.
+                        `percentage`: The company contributes a percentage of the payroll amount per payroll period. If elective is true, the contribution is matching, dollar-for-dollar.
 
-                        "tiered": The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching scheme.
+                        `tiered`: The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching scheme.
+                      enum:
+                        - amount
+                        - percentage
+                        - tiered
                     value:
                       description: |-
                         For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
@@ -2264,7 +2271,7 @@ paths:
                                   If this is the first tier, a value of "5" means the company contribution will match employee deductions from 0% up to and including 5% of payroll.
                 elective:
                   type: boolean
-                  description: Whether the company contribution is elective (aka "matching"). For "tiered" contribution types this is ignored and assumed to be true.
+                  description: 'Whether the company contribution is elective (aka "matching"). For `tiered`, `elective_amount`, and `elective_percentage` contribution types this is ignored and assumed to be `true`.'
                   default: false
                 company_contribution_annual_maximum:
                   type: string

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -3638,63 +3638,7 @@ paths:
       summary: Get Federal Tax Details
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  version:
-                    type: string
-                    description: 'The current version of the object. See the [versioning guide](https://docs.gusto.com/docs/api/ZG9jOjUyNzM0MTc-versioning) for details using this field.'
-                  tax_payer_type:
-                    type: string
-                    description: |-
-                      What type of tax entity the company is. One of:
-                      - C-Corporation
-                      - S-Corporation
-                      - Sole proprietor
-                      - LLC
-                      - LLP
-                      - Limited partnership
-                      - Co-ownership
-                      - Association
-                      - Trusteeship
-                      - General partnership
-                      - Joint venture
-                      - Non-Profit
-                  ein:
-                    type: string
-                    description: The company's EIN
-                  taxable_as_scorp:
-                    type: boolean
-                    description: |-
-                      Whether the company is taxed as an S-Corporation. Tax payer types that may be taxed as an S-Corporation include:
-                      - S-Corporation
-                      - C-Corporation
-                      - LLC
-                  filing_form:
-                    type: string
-                    description: |-
-                      The form used by the company for federal tax filing. One of:
-                      - 941 (Quarterly federal tax return form)
-                      - 944 (Annual federal tax return form)
-                  ein_verified:
-                    type: boolean
-                    description: 'Whether the EIN was able to be verified as a valid EIN with the IRS. '
-                  legal_name:
-                    type: string
-                    description: The legal name of the company
-              examples:
-                Example:
-                  value:
-                    version: 6cb95e00540706ca48d4577b3c839fbe
-                    tax_payer_type: LLP
-                    ein: '561354858'
-                    taxable_as_scorp: false
-                    filing_form: '944'
-                    ein_verified: false
-                    legal_name: Acme Corp.
+          $ref: '#/components/responses/Federal-Tax-Details-Object'
       operationId: get-v1-companies-company_id_or_uuid-federal_tax_details
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
@@ -3709,53 +3653,7 @@ paths:
       summary: Update Federal Tax Details
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  version:
-                    type: string
-                    description: 'The current version of the object. See the [versioning guide](https://docs.gusto.com/docs/api/ZG9jOjUyNzM0MTc-versioning) for details using this field.'
-                  tax_payer_type:
-                    type: string
-                    description: |-
-                      What type of tax entity the company is. One of:
-                      - C-Corporation
-                      - S-Corporation
-                      - Sole proprietor
-                      - LLC
-                      - LLP
-                      - Limited partnership
-                      - Co-ownership
-                      - Association
-                      - Trusteeship
-                      - General partnership
-                      - Joint venture
-                      - Non-Profit
-                  ein:
-                    type: string
-                    description: The company's EIN
-                  taxable_as_scorp:
-                    type: boolean
-                    description: |-
-                      Whether the company is taxed as an S-Corporation. Tax payer types that may be taxed as an S-Corporation include:
-                      - S-Corporation
-                      - C-Corporation
-                      - LLC
-                  filing_form:
-                    type: string
-                    description: |-
-                      The form used by the company for federal tax filing. One of:
-                      - 941 (Quarterly federal tax return form)
-                      - 944 (Annual federal tax return form)
-                  ein_verified:
-                    type: boolean
-                    description: 'Whether the EIN was able to be verified as a valid EIN with the IRS. '
-                  legal_name:
-                    type: string
-                    description: The legal name of the company
+          $ref: '#/components/responses/Federal-Tax-Details-Object'
       operationId: put-v1-companies-company_id_or_uuid-federal_tax_details
       requestBody:
         content:

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -2156,7 +2156,10 @@ paths:
       tags:
         - Benefits
       operationId: post-employee-ytd-benefit-amounts-from-different-company
-      description: 'Year-to-date benefit amounts from a different company represents the amount of money added to an employees plan during a current year, made outside of the current contribution when they were employed at a different company.'
+      description: |-
+        Year-to-date benefit amounts from a different company represents the amount of money added to an employees plan during a current year, made outside of the current contribution when they were employed at a different company.
+
+        `scope: employee_benefits.write`
       requestBody:
         $ref: '#/components/requestBodies/post-employee-ytd-benefit-amounts-from-different-company'
       responses:
@@ -2178,7 +2181,10 @@ paths:
         '200':
           $ref: '#/components/responses/Employee-Benefit-Object'
       operationId: get-v1-employee_benefits-employee_benefit_id
-      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+      description: |-
+        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+
+        `scope: employee_benefits.read`
     put:
       summary: Update an employee benefit
       tags:
@@ -2187,7 +2193,10 @@ paths:
         '200':
           $ref: '#/components/responses/Employee-Benefit-Object'
       operationId: put-v1-employee_benefits-employee_benefit_id
-      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+      description: |-
+        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+
+        `scope: employee_benefits.write`
       requestBody:
         content:
           application/json:
@@ -2312,7 +2321,10 @@ paths:
         '204':
           description: No Content
       operationId: delete-v1-employee_benefits-employee_benefit_id
-      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+      description: |-
+        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
+
+        `scope: employee_benefits.write`
   '/v1/companies/{company_id_or_uuid}/pay_periods':
     parameters:
       - schema:
@@ -2419,6 +2431,8 @@ paths:
 
 
         By default, this endpoint returns every current and past pay period for a company. Since companies can process payroll as often as every week, there can be up to 53 pay periods a year. If a company has been running payroll with Gusto for five years, this endpoint could return up to 265 pay periods. Use the `start_date` and `end_date` parameters to reduce the scope of the response.
+
+        `scope: payrolls.read`
       parameters:
         - schema:
             type: string
@@ -2453,6 +2467,8 @@ paths:
         * Hour and dollar amounts are returned as string representations of numeric decimals.
         * Hours are represented to the thousands place; dollar amounts are represented to the cent.
         * Every eligible compensation is returned for each employee. If no data has yet be inserted for a given field, it defaults to “0.00” (for fixed amounts) or “0.000” (for hours ).
+
+        `scope: payrolls.read`
       parameters:
         - schema:
             type: boolean
@@ -2544,7 +2560,10 @@ paths:
         '200':
           $ref: '#/components/responses/Payroll-Object'
       operationId: put-v1-companies-company_id-payrolls
-      description: This endpoint allows you to update information for one or more employees for a specific **unprocessed** payroll.
+      description: |-
+        This endpoint allows you to update information for one or more employees for a specific **unprocessed** payroll.
+
+        `scope: payrolls.write`
       requestBody:
         content:
           application/json:
@@ -2652,6 +2671,8 @@ paths:
         * Hour and dollar amounts are returned as string representations of numeric decimals.
         * Hours are represented to the thousands place; dollar amounts are represented to the cent.
         * Every eligible compensation is returned for each employee. If no data has yet be inserted for a given field, it defaults to “0.00” (for fixed amounts) or “0.000” (for hours ).
+
+        `scope: payrolls.read`
       parameters:
         - schema:
             type: string
@@ -2699,6 +2720,8 @@ paths:
         This endpoint allows you to update information for one or more employees for a specific **unprocessed** payroll.
 
         The payrolls are identified by their pay periods’ start_date and end_date. Both are required and must correspond with an existing, unprocessed payroll. *If the dates do not match, the entire request will be rejected.* This was an explicit design decision to remove any assumptions around the timespan for data sent.
+
+        `scope: payrolls.write`
       requestBody:
         content:
           application/json:
@@ -3114,7 +3137,10 @@ paths:
                           - banana
                           - orange
       operationId: get-v1-employees-employee_id-custom_fields
-      description: Returns a list of the employee's custom fields.
+      description: |-
+        Returns a list of the employee's custom fields.
+
+        `scope: employees.read`
   '/v1/companies/{company_id}/custom_fields':
     parameters:
       - schema:
@@ -3125,7 +3151,10 @@ paths:
         description: The ID of the company
     get:
       summary: Get the custom fields of a company
-      description: Returns a list of the custom fields of the company. Useful when you need to know the schema of custom fields for an entire company
+      description: |-
+        Returns a list of the custom fields of the company. Useful when you need to know the schema of custom fields for an entire company
+
+        `scope: companies.read`
       operationId: get-v1-companies-company_id-custom_fields
       tags:
         - Custom Fields
@@ -3188,7 +3217,10 @@ paths:
         '200':
           $ref: '#/components/responses/Time-Off-Request-Object'
       operationId: get-v1-companies-company_id-time_off_requests-time_off_request_id
-      description: Details of a single time off request
+      description: |-
+        Details of a single time off request
+
+        `scope: time_off_requests.read`
   '/v1/companies/{company_id}/job_applicants':
     parameters:
       - schema:
@@ -3209,6 +3241,8 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Create a job applicant.
+
+        `scope: job_applicants.write`
       requestBody:
         content:
           application/json:
@@ -3277,6 +3311,8 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Returns all job applicants for a company.
+
+        `scope: job_applicants.read`
   '/v1/companies/{company_id}/job_applicants/{job_applicant_uuid}':
     parameters:
       - schema:
@@ -3303,6 +3339,8 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Returns a single job applicant.
+
+        `scope: job_applicants.read`
     put:
       summary: Update a job applicant
       operationId: put-v1-companies-company_id-job_applicants-job_applicant_uuid
@@ -3313,6 +3351,8 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Update an existing job applicant (only allowed when the job applicant has not been imported).
+
+        `scope: job_applicants.write`
       requestBody:
         content:
           application/json:
@@ -3377,6 +3417,8 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Permanently remove a job applicant by uuid (only allowed when the job applicant has not been imported).
+
+        `scope: job_applicants.write`
       tags:
         - Job Applicants (Beta)
   '/v1/companies/{company_id}/payrolls/{payroll_id}/calculate':
@@ -3512,7 +3554,10 @@ paths:
                     reversed_employee_ids:
                       - 3
       operationId: get-v1-companies-company_id_or_uuid-payroll_reversals
-      description: Returns all approved Payroll Reversals for a Company.
+      description: |-
+        Returns all approved Payroll Reversals for a Company.
+
+        `scope: payrolls.read`
   '/v1/companies/{company_id}/admins':
     parameters:
       - schema:

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -2068,12 +2068,12 @@ paths:
                         - amount
                     value:
                       description: |-
-                        For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
+                        For the `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.
 
-                        For "tiered" contribution types, an array of tiers.
+                        For the `tiered` contribution type, an array of tiers.
                       oneOf:
                         - type: string
-                          description: 'For `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.'
+                          description: 'For the `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.'
                         - type: array
                           description: 'For `tiered` contribution types, an array of tiers.'
                           items:
@@ -2246,12 +2246,12 @@ paths:
                         - tiered
                     value:
                       description: |-
-                        For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
+                        For the `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.
 
-                        For "tiered" contribution types, an array of tiers.
+                        For the `tiered` contribution type, an array of tiers.
                       oneOf:
                         - type: string
-                          description: 'For `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.'
+                          description: 'For the `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.'
                         - type: array
                           description: 'For `tiered` contribution types, an array of tiers.'
                           items:
@@ -5893,12 +5893,11 @@ components:
                 "tiered": The company contribution varies according to the size of the employee deduction.
             value:
               description: |-
-                For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
+                For the `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.
 
-                For "tiered" contribution types, an array of tiers.
+                For the `tiered` contribution type, an array of tiers.
               oneOf:
                 - type: string
-                  properties: {}
                 - type: object
                   properties:
                     tiers:

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -2073,9 +2073,9 @@ paths:
                         For "tiered" contribution types, an array of tiers.
                       oneOf:
                         - type: string
-                          description: 'For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.'
+                          description: 'For `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.'
                         - type: array
-                          description: 'For "tiered" contribution types, an array of tiers.'
+                          description: 'For `tiered` contribution types, an array of tiers.'
                           items:
                             type: object
                             description: A single tier of a tiered matching scheme.
@@ -2251,9 +2251,9 @@ paths:
                         For "tiered" contribution types, an array of tiers.
                       oneOf:
                         - type: string
-                          description: 'For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.'
+                          description: 'For `amount` and `percentage` contribution types, the value of the corresponding amount or percentage.'
                         - type: array
-                          description: 'For "tiered" contribution types, an array of tiers.'
+                          description: 'For `tiered` contribution types, an array of tiers.'
                           items:
                             type: object
                             description: A single tier of a tiered matching scheme.

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -3922,6 +3922,7 @@ paths:
       parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+
         Create a company signatory who can legally sign forms. Please note that there can only be a single primary signatory in a company. You can retrieve the current primary signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
       responses:
         '201':
@@ -3998,6 +3999,7 @@ paths:
       parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+
         Delete a company signatory. Please note that you can retrieve the signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
       responses:
         '204':
@@ -4018,6 +4020,7 @@ paths:
       parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+
         Get a list of all company's forms
       responses:
         '200':
@@ -4038,6 +4041,7 @@ paths:
       parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+
         Get a company form
       responses:
         '200':
@@ -4058,6 +4062,7 @@ paths:
       parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+
         Get the link to the form PDF
       responses:
         '200':
@@ -4097,6 +4102,7 @@ paths:
       parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+
         Sign a company form
       responses:
         '200':
@@ -4143,6 +4149,7 @@ paths:
       parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+
         Generate a link to access a workflow in Gusto whitelabel UI.
       responses:
         '201':

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -13,18 +13,15 @@ tags:
   - name: Employee Bank Accounts (Beta)
   - name: Employee Payment Method (Beta)
   - name: Employees
-  - name: Federal Tax Details (Beta)
-  - name: Flows (Beta)
-  - name: Forms (Beta)
   - name: Garnishments
   - name: Job Applicants (Beta)
   - name: Jobs
   - name: Locations
   - name: Pay Schedules
   - name: Payroll
-  - name: Signatories (Beta)
   - name: Terminations
   - name: Time Off Requests
+  - name: Federal Tax Details (Beta)
 info:
   title: Gusto API
   version: '1.0'
@@ -43,10 +40,7 @@ paths:
     get:
       summary: Get an employee
       operationId: get-v1-employees
-      description: |
-        Get an employee.
-
-        `scope: employees.read`
+      description: Get an employee.
       parameters:
         - in: query
           name: include
@@ -65,10 +59,7 @@ paths:
     put:
       summary: Update an employee
       operationId: put-v1-employees
-      description: |-
-        Update an employee.
-
-        `scope: employees.write`
+      description: Update an employee.
       requestBody:
         content:
           application/json:
@@ -126,10 +117,7 @@ paths:
     get:
       summary: Get a company
       operationId: get-v1-companies
-      description: |-
-        Get a company.
-
-        `scope: companies.read`
+      description: Get a company.
       parameters: []
       responses:
         '200':
@@ -171,10 +159,7 @@ paths:
                 - custom_fields
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/perParam'
-      description: |-
-        Get all of the employees, onboarding, active and terminated, for a given company.
-
-        `scope: employees.read`
+      description: 'Get all of the employees, onboarding, active and terminated, for a given company.'
       responses:
         '200':
           $ref: '#/components/responses/Employee-List'
@@ -220,10 +205,7 @@ paths:
                   ssn: '123456294'
         description: Create an employee.
       parameters: []
-      description: |-
-        Create an employee.
-
-        `scope: employees.write`
+      description: Create an employee.
       responses:
         '201':
           $ref: '#/components/responses/Employee-Object'
@@ -244,10 +226,7 @@ paths:
           $ref: '#/components/responses/Job-Object'
       operationId: get-v1-jobs-job_id
       parameters: []
-      description: |-
-        Get a job.
-
-        `scope: jobs.read`
+      description: Get a job.
       tags:
         - Jobs
     put:
@@ -256,10 +235,7 @@ paths:
         '200':
           $ref: '#/components/responses/Job-Object'
       operationId: put-v1-jobs-job_id
-      description: |-
-        Update a job.
-
-        `scope: jobs.write`
+      description: Update a job.
       parameters: []
       requestBody:
         content:
@@ -297,10 +273,7 @@ paths:
         '204':
           description: No Content
       operationId: delete-v1-jobs-job_id
-      description: |-
-        Deletes a specific job that an employee holds.
-
-        `scope: jobs.write`
+      description: Deletes a specific job that an employee holds.
   '/v1/employees/{employee_id}/jobs':
     parameters:
       - schema:
@@ -318,10 +291,7 @@ paths:
         '200':
           $ref: '#/components/responses/Job-List'
       operationId: get-v1-employees-employee_id-jobs
-      description: |-
-        Get all of the jobs that an employee holds.
-
-        `scope: jobs.read`
+      description: Get all of the jobs that an employee holds.
       tags:
         - Jobs
     post:
@@ -330,10 +300,7 @@ paths:
         '201':
           $ref: '#/components/responses/Job-Object'
       operationId: post-v1-jobs-job_id
-      description: |-
-        Create a job.
-
-        `scope: jobs.write`
+      description: Create a job.
       parameters: []
       requestBody:
         content:
@@ -378,8 +345,6 @@ paths:
         Company locations represent all addresses associated with a company. These can be filing addesses, mailing addresses, and/or work locations; one address may serve multiple, or all, purposes.
 
         Since all company locations are subsets of locations, retrieving or updating an individual record should be done via the locations endpoints.
-
-        `scope: companies.read`
       tags:
         - Locations
     post:
@@ -392,8 +357,6 @@ paths:
         Company locations represent all addresses associated with a company. These can be filing addesses, mailing addresses, and/or work locations; one address may serve multiple, or all, purposes.
 
         Since all company locations are subsets of locations, retrieving or updating an individual record should be done via the locations endpoints.
-
-        scope: companies.write
       parameters: []
       requestBody:
         content:
@@ -503,10 +466,7 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: get-v1-locations-location_id
-      description: |-
-        Get a location.
-
-        `scope: companies.read`
+      description: Get a location.
       parameters: []
       tags:
         - Locations
@@ -516,10 +476,7 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: put-v1-locations-location_id
-      description: |-
-        Update a location.
-
-        scope: companies.write
+      description: Update a location.
       requestBody:
         content:
           application/json:
@@ -578,10 +535,7 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Object'
       operationId: get-v1-contractors-contractor_id
-      description: |-
-        Get a contractor.
-
-        `scope: employees.read`
+      description: Get a contractor.
     put:
       summary: Update a contractor
       tags:
@@ -590,10 +544,7 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Object'
       operationId: put-v1-contractors-contractor_id
-      description: |-
-        Update a contractor.
-
-        `scope: employees.write`
+      description: Update a contractor.
       requestBody:
         content:
           application/json:
@@ -672,10 +623,7 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-List'
       operationId: get-v1-companies-company_id-contractors
-      description: |-
-        Get all contractors, active and inactive, individual and business, for a company.
-
-        `scope: employees.read`
+      description: 'Get all contractors, active and inactive, individual and business, for a company.'
     post:
       summary: Create a contractor
       tags:
@@ -684,10 +632,7 @@ paths:
         '201':
           $ref: '#/components/responses/Contractor-Object'
       operationId: post-v1-companies-company_id-contractors
-      description: |-
-        Create an individual or business contractor.
-
-        `scope: employees.write`
+      description: Create an individual or business contractor.
       requestBody:
         content:
           application/json:
@@ -772,10 +717,7 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Payments'
       operationId: get-v1-companies-company_id-contractor_payments
-      description: |-
-        Returns an object containing individual contractor payments, within a given time period, including totals.
-
-        `scope: payrolls.read`
+      description: 'Returns an object containing individual contractor payments, within a given time period, including totals.'
       parameters:
         - schema:
             type: string
@@ -866,10 +808,7 @@ paths:
         '200':
           $ref: '#/components/responses/Contractor-Payment-Object'
       operationId: get-v1-companies-company_id-contractor_payment-contractor-payment
-      description: |-
-        Returns a single contractor payments
-
-        `scope: payrolls.read`
+      description: Returns a single contractor payments
     delete:
       summary: Cancel a contractor payment (Beta)
       tags:
@@ -901,8 +840,6 @@ paths:
         Compensations contain information on how much is paid out for a job. Jobs may have many compensations, but only one that is active. The current compensation is the one with the most recent `effective_date`.
 
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error.
-
-        `scope: jobs.read`
       tags:
         - Compensations
     put:
@@ -917,8 +854,6 @@ paths:
         Compensations contain information on how much is paid out for a job. Jobs may have many compensations, but only one that is active. The current compensation is the one with the most recent `effective_date`.
 
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error
-
-        `scope: jobs.write`
       requestBody:
         content:
           application/json:
@@ -985,8 +920,6 @@ paths:
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error.
 
         Use the `flsa_status` to determine if an employee is elibgle for overtime.
-
-        `scope: jobs.read`
       tags:
         - Compensations
     post:
@@ -998,8 +931,6 @@ paths:
         Compensations contain information on how much is paid out for a job. Jobs may have many compensations, but only one that is active. The current compensation is the one with the most recent `effective_date`.
 
         Note: Currently, jobs are arbitrarily limited to a single compensation as multiple compensations per job are not yet available in Gusto. The API is architected as if multiple compensations may exist, so integrations should integrate under the same assumption. The only exception is that creating a compensation with the same `job_id` as another will fail with a relevant error
-
-        `scope: jobs.write`
       responses:
         '201':
           $ref: '#/components/responses/Compensation-Object'
@@ -1066,10 +997,7 @@ paths:
         '200':
           $ref: '#/components/responses/Garnishment-List'
       operationId: get-v1-employees-employee_id-garnishments
-      description: |-
-        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
-
-        `scope: employees.read`
+      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
     post:
       summary: Create a garnishment
       tags:
@@ -1078,10 +1006,7 @@ paths:
         '201':
           $ref: '#/components/responses/Garnishment-Object'
       operationId: post-v1-employees-employee_id-garnishments
-      description: |-
-        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
-
-        `scope: employees.write`
+      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
       requestBody:
         content:
           application/json:
@@ -1163,10 +1088,7 @@ paths:
         '200':
           $ref: '#/components/responses/Garnishment-Object'
       operationId: get-v1-garnishments-garnishment_id
-      description: |-
-        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
-
-        `scope: employees.read`
+      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
     put:
       summary: Update a garnishment
       tags:
@@ -1175,10 +1097,7 @@ paths:
         '200':
           $ref: '#/components/responses/Garnishment-Object'
       operationId: put-v1-garnishments-garnishment_id
-      description: |-
-        Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.
-
-        `scope: employees.write`
+      description: 'Garnishments, or employee deductions, are fixed amounts or percentages deducted from an employee’s pay. They can be deducted a specific number of times or on a recurring basis. Garnishments can also have maximum deductions on a yearly or per-pay-period bases. Common uses for garnishments are court-ordered payments for child support or back taxes. Some companies provide loans to their employees that are repaid via garnishments.'
       requestBody:
         content:
           application/json:
@@ -1261,8 +1180,6 @@ paths:
         Terminations are created whenever an employee is scheduled to leave the company. The only things required are an effective date (their last day of work) and whether they should receive their wages in a one-off termination payroll or with the rest of the company.
 
         Note that some states require employees to receive their final wages within 24 hours (unless they consent otherwise,) in which case running a one-off payroll may be the only option.
-
-        `scope: employees.read`
     post:
       summary: Create an employee termination
       tags:
@@ -1275,8 +1192,6 @@ paths:
         Terminations are created whenever an employee is scheduled to leave the company. The only things required are an effective date (their last day of work) and whether they should receive their wages in a one-off termination payroll or with the rest of the company.
 
         Note that some states require employees to receive their final wages within 24 hours (unless they consent otherwise,) in which case running a one-off payroll may be the only option.
-
-        `scope: employees.write`
       requestBody:
         content:
           application/json:
@@ -1311,7 +1226,7 @@ paths:
         '200':
           $ref: '#/components/responses/Time-Off-Request-List'
       operationId: get-v1-companies-company_id-time_off_requests
-      description: |-
+      description: |
         Get all time off requests, past and present, for a company.
 
         In order to reduce the number of time off requests returned in a single response, or to retrieve time off requests from a time period of interest, you may use the `start_date` and `end_date` parameters.
@@ -1329,8 +1244,6 @@ paths:
         `?start_date='2019-05-01'&end_date='2019-08-31'`
 
         Returns all time off requests where the request start date is equal to or after May 1, 2019 and the request end date is equal to or before August 31, 2019.
-
-        `scope: time_off_requests.read`
       parameters:
         - schema:
             type: string
@@ -1405,10 +1318,7 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: get-v1-employees-employee_id-home_address
-      description: |-
-        The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
-
-        `scope: employees.read`
+      description: The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
     put:
       summary: Update an employee's home address
       tags:
@@ -1417,10 +1327,7 @@ paths:
         '200':
           $ref: '#/components/responses/Location-Object'
       operationId: put-v1-employees-employee_id-home_address
-      description: |-
-        The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
-
-        `scope: employees.write`
+      description: The home address of an employee is used to determine certain tax information about them. Addresses are geocoded on create and update to ensure validity.
       requestBody:
         content:
           application/json:
@@ -1470,10 +1377,7 @@ paths:
         '200':
           $ref: '#/components/responses/Pay-Schedule-List'
       operationId: get-v1-companies-company_id-pay_schedules
-      description: |-
-        The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
-
-        `scope: payrolls.read`
+      description: The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
       tags:
         - Pay Schedules
     post:
@@ -1555,10 +1459,7 @@ paths:
         '200':
           $ref: '#/components/responses/Pay-Schedule-Object'
       operationId: get-v1-companies-company_id-pay_schedules-pay_schedule_id
-      description: |-
-        The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
-
-        `scope: payrolls.read`
+      description: The pay schedule object in Gusto captures the details of when employees work and when they should be paid. A company can have multiple pay schedules.
       tags:
         - Pay Schedules
     put:
@@ -1685,20 +1586,7 @@ paths:
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
-        Verify a company bank account by confirming the two micro-deposits sent to the bank account. Note that the order of the two deposits specified in request parameters does not matter. There's a maximum of 5 verification attempts, after which we will automatically initiate a new set of micro-deposits and require the bank account to be verified with the new micro-deposits.
-
-        ### Bank account verification in demo
-
-        We provide the endpoint `POST '/v1/companies/{company_id_or_uuid}/bank_accounts/{bank_account_uuid}/send_test_deposits'` to facilitate bank account verification in the demo environment. This endpoint simulates the micro-deposits transfer and returns them in the reponse. You can call this endpoint as many times as you wish to retrieve the values of the two micro deposits.
-
-        ```
-          POST '/v1/companies/89771af8-b964-472e-8064-554dfbcb56d9/bank_accounts/ade55e57-4800-4059-9ecd-fa29cfeb6dd2/send_test_deposits'
-
-          {
-            "deposit_1": 0.02,
-            "deposit_2": 0.42
-          }
-        ```
+        Verify a company bank account by confirming the two micro-deposits sent to the bank account. Note that the order of the two deposits specified in request parameters does not matter.
       requestBody:
         content:
           application/json:
@@ -1730,8 +1618,6 @@ paths:
         Returns all benefits supported by Gusto.
 
         The benefit object in Gusto contains high level information about a particular benefit type and its tax considerations. When companies choose to offer a benefit, they are creating a Company Benefit object associated with a particular benefit.
-
-        `scope: benefits.read`
       tags:
         - Benefits
   '/v1/benefits/{benefit_id}':
@@ -1749,8 +1635,6 @@ paths:
         Returns a benefit supported by Gusto.
 
         The benefit object in Gusto contains high level information about a particular benefit type and its tax considerations. When companies choose to offer a benefit, they are creating a Company Benefit object associated with a particular benefit.
-
-        `scope: benefits.read`
       tags:
         - Benefits
       responses:
@@ -1776,8 +1660,6 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
-
-        `scope: company_benefits.read`
     post:
       summary: Create a company benefit
       tags:
@@ -1790,8 +1672,6 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
-
-        `scope: company_benefits.write`
       requestBody:
         content:
           application/json:
@@ -1838,8 +1718,6 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
-
-        `scope: company_benefits.read`
     put:
       summary: Update a company benefit
       tags:
@@ -1852,8 +1730,6 @@ paths:
         Company benefits represent the benefits that a company is offering to employees. This ties together a particular supported benefit with the company-specific information for the offering of that benefit.
 
         Note that company benefits can be deactivated only when no employees are enrolled.
-
-        `scope: company_benefits:write`
       requestBody:
         content:
           application/json:
@@ -1902,8 +1778,6 @@ paths:
 
         #### Custom Earning Type
         Custom earning types are all the other earning types added specifically for a company.
-
-        `scope: payrolls.read`
     post:
       summary: Create a custom earning type
       tags:
@@ -1916,8 +1790,6 @@ paths:
         Create a custom earning type.
 
         If an inactive earning type exists with the same name, this will reactivate it instead of creating a new one.
-
-        `scope: payrolls:write`
       requestBody:
         content:
           application/json:
@@ -1955,10 +1827,7 @@ paths:
         '200':
           $ref: '#/components/responses/Earning-Type-Object'
       operationId: put-v1-companies-company_id-earning_types-earning_type_uuid
-      description: |-
-        Update an earning type.
-
-        `scope: payrolls.write`
+      description: Update an earning type.
       requestBody:
         content:
           application/json:
@@ -1980,10 +1849,7 @@ paths:
         '204':
           description: No Content
       operationId: delete-v1-companies-company_id-earning_types-earning_type_uuid
-      description: |-
-        Deactivate an earning type.
-
-        `scope: payrolls.write`
+      description: Deactivate an earning type.
   '/v1/employees/{employee_id}/employee_benefits':
     parameters:
       - schema:
@@ -2007,8 +1873,6 @@ paths:
         Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
 
         Returns an array of all employee benefits for this employee
-
-        `scope: employee_benefits.read`
     post:
       summary: Create an employee benefit
       tags:
@@ -2017,10 +1881,7 @@ paths:
         '201':
           $ref: '#/components/responses/Employee-Benefit-Object'
       operationId: post-v1-employees-employee_id-employee_benefits
-      description: |-
-        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
-
-        `scope: employee_benefits.write`
+      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
       requestBody:
         content:
           application/json:
@@ -2040,57 +1901,14 @@ paths:
                   type: string
                   default: '0.00'
                   description: 'The amount to be deducted, per pay period, from the employee''s pay.'
-                company_contribution:
-                  type: string
-                  default: '0.00'
-                  description: 'The amount to be paid, per pay period, by the company.'
-                  deprecated: true
-                employee_deduction_annual_maximum:
-                  type: string
-                  description: The maximum employee deduction amount per year. A null value signifies no limit.
-                  nullable: true
-                company_contribution_annual_maximum:
-                  type: string
-                  description: The maximum company contribution amount per year. A null value signifies no limit.
-                  nullable: true
-                limit_option:
-                  type: string
-                  description: 'Some benefits require additional information to determine their limit. For example, for an HSA benefit, the limit option should be either "Family" or "Individual". For a Dependent Care FSA benefit, the limit option should be either "Joint Filing or Single" or "Married and Filing Separately".'
-                  nullable: true
                 deduct_as_percentage:
                   type: boolean
                   default: false
                   description: Whether the employee deduction amount should be treated as a percentage to be deducted from each payroll.
-                catch_up:
-                  type: boolean
-                  default: false
-                  description: Whether the employee should use a benefit’s "catch up" rate. Only Roth 401k and 401k benefits use this value for employees over 50.
-                contribute_as_percentage:
-                  type: boolean
-                  default: false
-                  description: Whether the company contribution amount should be treated as a percentage to be deducted from each payroll.
-                  deprecated: true
-                coverage_amount:
+                employee_deduction_annual_maximum:
                   type: string
-                  description: 'The amount that the employee is insured for. Note: company contribution cannot be present if coverage amount is set.'
+                  description: The maximum employee deduction amount per year. A null value signifies no limit.
                   nullable: true
-                deduction_reduces_taxable_income:
-                  type: string
-                  enum:
-                    - unset
-                    - reduces_taxable_income
-                    - does_not_reduce_taxable_income
-                    - null
-                  description: 'Whether the employee deduction reduces taxable income or not. Only valid for Group Term Life benefits. Note: when the value is not "unset", coverage amount and coverage salary multiplier are ignored.'
-                  nullable: true
-                coverage_salary_multiplier:
-                  type: string
-                  default: '0.00'
-                  description: 'The coverage amount as a multiple of the employee’s salary. Only applicable for Group Term Life benefits. Note: cannot be set if coverage amount is also set.'
-                elective:
-                  type: boolean
-                  description: Whether the company contribution is elective (aka "matching"). For "tiered" contribution types this is ignored and assumed to be true.
-                  default: false
                 contribution:
                   type: object
                   description: An object representing the company contribution type and value.
@@ -2104,7 +1922,7 @@ paths:
 
                         "percentage": The company contributes a percentage of the payroll amount per payroll period. If elective is true, the contribution is matching, dollar-for-dollar.
 
-                        "tiered": The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching schedule.
+                        "tiered": The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching scheme.
                     value:
                       description: |-
                         For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
@@ -2113,7 +1931,9 @@ paths:
                       oneOf:
                         - type: string
                           properties: {}
+                          description: 'For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.'
                         - type: array
+                          description: 'For "tiered" contribution types, an array of tiers.'
                           items:
                             type: object
                             description: A single tier of a tiered matching scheme.
@@ -2129,6 +1949,49 @@ paths:
                                   For example, a value of "5" means the company contribution will match employee deductions from the previous tier's threshold up to and including 5% of payroll.
 
                                   If this is the first tier, a value of "5" means the company contribution will match employee deductions from 0% up to and including 5% of payroll.
+                elective:
+                  type: boolean
+                  description: Whether the company contribution is elective (aka "matching"). For "tiered" contribution types this is ignored and assumed to be true.
+                  default: false
+                company_contribution_annual_maximum:
+                  type: string
+                  description: The maximum company contribution amount per year. A null value signifies no limit.
+                  nullable: true
+                limit_option:
+                  type: string
+                  description: 'Some benefits require additional information to determine their limit. For example, for an HSA benefit, the limit option should be either "Family" or "Individual". For a Dependent Care FSA benefit, the limit option should be either "Joint Filing or Single" or "Married and Filing Separately".'
+                  nullable: true
+                catch_up:
+                  type: boolean
+                  default: false
+                  description: Whether the employee should use a benefit’s "catch up" rate. Only Roth 401k and 401k benefits use this value for employees over 50.
+                coverage_amount:
+                  type: string
+                  description: 'The amount that the employee is insured for. Note: company contribution cannot be present if coverage amount is set.'
+                  nullable: true
+                coverage_salary_multiplier:
+                  type: string
+                  default: '0.00'
+                  description: 'The coverage amount as a multiple of the employee’s salary. Only applicable for Group Term Life benefits. Note: cannot be set if coverage amount is also set.'
+                deduction_reduces_taxable_income:
+                  type: string
+                  enum:
+                    - unset
+                    - reduces_taxable_income
+                    - does_not_reduce_taxable_income
+                    - null
+                  description: 'Whether the employee deduction reduces taxable income or not. Only valid for Group Term Life benefits. Note: when the value is not "unset", coverage amount and coverage salary multiplier are ignored.'
+                  nullable: true
+                company_contribution:
+                  type: string
+                  default: '0.00'
+                  description: 'The amount to be paid, per pay period, by the company.'
+                  deprecated: true
+                contribute_as_percentage:
+                  type: boolean
+                  default: false
+                  description: Whether the company contribution amount should be treated as a percentage to be deducted from each payroll.
+                  deprecated: true
               required:
                 - company_benefit_id
             examples:
@@ -2154,10 +2017,7 @@ paths:
       tags:
         - Benefits
       operationId: post-employee-ytd-benefit-amounts-from-different-company
-      description: |-
-        Year-to-date benefit amounts from a different company represents the amount of money added to an employees plan during a current year, made outside of the current contribution when they were employed at a different company.
-
-        `scope: employee_benefits.write`
+      description: 'Year-to-date benefit amounts from a different company represents the amount of money added to an employees plan during a current year, made outside of the current contribution when they were employed at a different company.'
       requestBody:
         $ref: '#/components/requestBodies/post-employee-ytd-benefit-amounts-from-different-company'
       responses:
@@ -2179,10 +2039,7 @@ paths:
         '200':
           $ref: '#/components/responses/Employee-Benefit-Object'
       operationId: get-v1-employee_benefits-employee_benefit_id
-      description: |-
-        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
-
-        `scope: employee_benefits.read`
+      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
     put:
       summary: Update an employee benefit
       tags:
@@ -2191,10 +2048,7 @@ paths:
         '200':
           $ref: '#/components/responses/Employee-Benefit-Object'
       operationId: put-v1-employee_benefits-employee_benefit_id
-      description: |-
-        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
-
-        `scope: employee_benefits.write`
+      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
       requestBody:
         content:
           application/json:
@@ -2213,15 +2067,57 @@ paths:
                   type: string
                   default: '0.00'
                   description: 'The amount to be deducted, per pay period, from the employee''s pay.'
-                company_contribution:
-                  type: string
-                  default: '0.00'
-                  description: 'The amount to be paid, per pay period, by the company.'
-                  deprecated: true
+                deduct_as_percentage:
+                  type: boolean
+                  default: false
+                  description: Whether the employee deduction amount should be treated as a percentage to be deducted from each payroll.
                 employee_deduction_annual_maximum:
                   type: string
                   description: The maximum employee deduction amount per year. A null value signifies no limit.
                   nullable: true
+                contribution:
+                  type: object
+                  description: An object representing the type and value of the company contribution.
+                  properties:
+                    type:
+                      type: string
+                      description: |-
+                        The company contribution scheme.
+
+                        "amount": The company contributes a fixed amount per payroll. If elective is true, the contribution is matching, dollar-for-dollar.
+
+                        "percentage": The company contributes a percentage of the payroll amount per payroll period. If elective is true, the contribution is matching, dollar-for-dollar.
+
+                        "tiered": The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching scheme.
+                    value:
+                      description: |-
+                        For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
+
+                        For "tiered" contribution types, an array of tiers.
+                      oneOf:
+                        - type: string
+                          description: 'For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.'
+                        - type: array
+                          description: 'For "tiered" contribution types, an array of tiers.'
+                          items:
+                            type: object
+                            description: A single tier of a tiered matching scheme.
+                            properties:
+                              rate:
+                                type: string
+                                description: The percentage of employee deduction within this tier the company contribution will match.
+                              threshold:
+                                type: string
+                                description: |-
+                                  The percentage threshold at which this tier ends (inclusive). 
+
+                                  For example, a value of "5" means the company contribution will match employee deductions from the previous tier's threshold up to and including 5% of payroll.
+
+                                  If this is the first tier, a value of "5" means the company contribution will match employee deductions from 0% up to and including 5% of payroll.
+                elective:
+                  type: boolean
+                  description: Whether the company contribution is elective (aka "matching"). For "tiered" contribution types this is ignored and assumed to be true.
+                  default: false
                 company_contribution_annual_maximum:
                   type: string
                   description: The maximum company contribution amount per year. A null value signifies no limit.
@@ -2230,15 +2126,6 @@ paths:
                   type: string
                   description: 'Some benefits require additional information to determine their limit. For example, for an HSA benefit, the limit option should be either "Family" or "Individual". For a Dependent Care FSA benefit, the limit option should be either "Joint Filing or Single" or "Married and Filing Separately".'
                   nullable: true
-                deduct_as_percentage:
-                  type: boolean
-                  default: false
-                  description: Whether the employee deduction amount should be treated as a percentage to be deducted from each payroll.
-                contribute_as_percentage:
-                  type: boolean
-                  default: false
-                  description: Whether the company contribution amount should be treated as a percentage to be deducted from each payroll.
-                  deprecated: true
                 catch_up:
                   type: boolean
                   default: false
@@ -2261,47 +2148,16 @@ paths:
                   type: string
                   default: '0.00'
                   description: 'The coverage amount as a multiple of the employee’s salary. Only applicable for Group Term Life benefits. Note: cannot be set if coverage amount is also set.'
-                elective:
+                company_contribution:
+                  type: string
+                  default: '0.00'
+                  description: 'The amount to be paid, per pay period, by the company.'
+                  deprecated: true
+                contribute_as_percentage:
                   type: boolean
-                  description: Whether the company contribution is elective (aka "matching"). For "tiered" contribution types this is ignored and assumed to be true.
                   default: false
-                contribution:
-                  type: object
-                  description: An object representing the type and value of the company contribution.
-                  properties:
-                    type:
-                      type: string
-                      description: |-
-                        The company contribution scheme.
-
-                        "amount": The company contributes a fixed amount per payroll. If elective is true, the contribution is matching, dollar-for-dollar.
-
-                        "percentage": The company contributes a percentage of the payroll amount per payroll period. If elective is true, the contribution is matching, dollar-for-dollar.
-
-                        "tiered": The size of the company contribution corresponds to the size of the employee deduction relative to a tiered matching schedule.
-                    value:
-                      description: |-
-                        For "amount" and "percentage" contribution types, the value of the corresponding amount or percentage.
-
-                        For "tiered" contribution types, an array of tiers.
-                      oneOf:
-                        - type: string
-                        - type: array
-                          items:
-                            type: object
-                            description: A single tier of a tiered matching scheme.
-                            properties:
-                              rate:
-                                type: string
-                                description: The percentage of employee deduction within this tier the company contribution will match.
-                              threshold:
-                                type: string
-                                description: |-
-                                  The percentage threshold at which this tier ends (inclusive). 
-
-                                  For example, a value of "5" means the company contribution will match employee deductions from the previous tier's threshold up to and including 5% of payroll.
-
-                                  If this is the first tier, a value of "5" means the company contribution will match employee deductions from 0% up to and including 5% of payroll.
+                  description: Whether the company contribution amount should be treated as a percentage to be deducted from each payroll.
+                  deprecated: true
               required:
                 - version
             examples:
@@ -2317,10 +2173,7 @@ paths:
         '204':
           description: No Content
       operationId: delete-v1-employee_benefits-employee_benefit_id
-      description: |-
-        Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
-
-        `scope: employee_benefits.write`
+      description: Employee benefits represent an employee enrolled in a particular company benefit. It includes information specific to that employee’s enrollment.
   '/v1/companies/{company_id_or_uuid}/pay_periods':
     parameters:
       - schema:
@@ -2427,8 +2280,6 @@ paths:
 
 
         By default, this endpoint returns every current and past pay period for a company. Since companies can process payroll as often as every week, there can be up to 53 pay periods a year. If a company has been running payroll with Gusto for five years, this endpoint could return up to 265 pay periods. Use the `start_date` and `end_date` parameters to reduce the scope of the response.
-
-        `scope: payrolls.read`
       parameters:
         - schema:
             type: string
@@ -2463,8 +2314,6 @@ paths:
         * Hour and dollar amounts are returned as string representations of numeric decimals.
         * Hours are represented to the thousands place; dollar amounts are represented to the cent.
         * Every eligible compensation is returned for each employee. If no data has yet be inserted for a given field, it defaults to “0.00” (for fixed amounts) or “0.000” (for hours ).
-
-        `scope: payrolls.read`
       parameters:
         - schema:
             type: boolean
@@ -2556,10 +2405,7 @@ paths:
         '200':
           $ref: '#/components/responses/Payroll-Object'
       operationId: put-v1-companies-company_id-payrolls
-      description: |-
-        This endpoint allows you to update information for one or more employees for a specific **unprocessed** payroll.
-
-        `scope: payrolls.write`
+      description: This endpoint allows you to update information for one or more employees for a specific **unprocessed** payroll.
       requestBody:
         content:
           application/json:
@@ -2667,8 +2513,6 @@ paths:
         * Hour and dollar amounts are returned as string representations of numeric decimals.
         * Hours are represented to the thousands place; dollar amounts are represented to the cent.
         * Every eligible compensation is returned for each employee. If no data has yet be inserted for a given field, it defaults to “0.00” (for fixed amounts) or “0.000” (for hours ).
-
-        `scope: payrolls.read`
       parameters:
         - schema:
             type: string
@@ -2716,8 +2560,6 @@ paths:
         This endpoint allows you to update information for one or more employees for a specific **unprocessed** payroll.
 
         The payrolls are identified by their pay periods’ start_date and end_date. Both are required and must correspond with an existing, unprocessed payroll. *If the dates do not match, the entire request will be rejected.* This was an explicit design decision to remove any assumptions around the timespan for data sent.
-
-        `scope: payrolls.write`
       requestBody:
         content:
           application/json:
@@ -3133,10 +2975,7 @@ paths:
                           - banana
                           - orange
       operationId: get-v1-employees-employee_id-custom_fields
-      description: |-
-        Returns a list of the employee's custom fields.
-
-        `scope: employees.read`
+      description: Returns a list of the employee's custom fields.
   '/v1/companies/{company_id}/custom_fields':
     parameters:
       - schema:
@@ -3147,10 +2986,7 @@ paths:
         description: The ID of the company
     get:
       summary: Get the custom fields of a company
-      description: |-
-        Returns a list of the custom fields of the company. Useful when you need to know the schema of custom fields for an entire company
-
-        `scope: companies.read`
+      description: Returns a list of the custom fields of the company. Useful when you need to know the schema of custom fields for an entire company
       operationId: get-v1-companies-company_id-custom_fields
       tags:
         - Custom Fields
@@ -3213,10 +3049,7 @@ paths:
         '200':
           $ref: '#/components/responses/Time-Off-Request-Object'
       operationId: get-v1-companies-company_id-time_off_requests-time_off_request_id
-      description: |-
-        Details of a single time off request
-
-        `scope: time_off_requests.read`
+      description: Details of a single time off request
   '/v1/companies/{company_id}/job_applicants':
     parameters:
       - schema:
@@ -3237,8 +3070,6 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Create a job applicant.
-
-        `scope: job_applicants.write`
       requestBody:
         content:
           application/json:
@@ -3307,8 +3138,6 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Returns all job applicants for a company.
-
-        `scope: job_applicants.read`
   '/v1/companies/{company_id}/job_applicants/{job_applicant_uuid}':
     parameters:
       - schema:
@@ -3335,8 +3164,6 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Returns a single job applicant.
-
-        `scope: job_applicants.read`
     put:
       summary: Update a job applicant
       operationId: put-v1-companies-company_id-job_applicants-job_applicant_uuid
@@ -3347,8 +3174,6 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Update an existing job applicant (only allowed when the job applicant has not been imported).
-
-        `scope: job_applicants.write`
       requestBody:
         content:
           application/json:
@@ -3413,8 +3238,6 @@ paths:
         *This endpoint is in beta - we will be making breaking changes based on developer feedback.
 
         Permanently remove a job applicant by uuid (only allowed when the job applicant has not been imported).
-
-        `scope: job_applicants.write`
       tags:
         - Job Applicants (Beta)
   '/v1/companies/{company_id}/payrolls/{payroll_id}/calculate':
@@ -3550,10 +3373,7 @@ paths:
                     reversed_employee_ids:
                       - 3
       operationId: get-v1-companies-company_id_or_uuid-payroll_reversals
-      description: |-
-        Returns all approved Payroll Reversals for a Company.
-
-        `scope: payrolls.read`
+      description: Returns all approved Payroll Reversals for a Company.
   '/v1/companies/{company_id}/admins':
     parameters:
       - schema:
@@ -3627,7 +3447,63 @@ paths:
       summary: Get Federal Tax Details
       responses:
         '200':
-          $ref: '#/components/responses/Federal-Tax-Details-Object'
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: 'The current version of the object. See the [versioning guide](https://docs.gusto.com/docs/api/ZG9jOjUyNzM0MTc-versioning) for details using this field.'
+                  tax_payer_type:
+                    type: string
+                    description: |-
+                      What type of tax entity the company is. One of:
+                      - C-Corporation
+                      - S-Corporation
+                      - Sole proprietor
+                      - LLC
+                      - LLP
+                      - Limited partnership
+                      - Co-ownership
+                      - Association
+                      - Trusteeship
+                      - General partnership
+                      - Joint venture
+                      - Non-Profit
+                  ein:
+                    type: string
+                    description: The company's EIN
+                  taxable_as_scorp:
+                    type: boolean
+                    description: |-
+                      Whether the company is taxed as an S-Corporation. Tax payer types that may be taxed as an S-Corporation include:
+                      - S-Corporation
+                      - C-Corporation
+                      - LLC
+                  filing_form:
+                    type: string
+                    description: |-
+                      The form used by the company for federal tax filing. One of:
+                      - 941 (Quarterly federal tax return form)
+                      - 944 (Annual federal tax return form)
+                  ein_verified:
+                    type: boolean
+                    description: 'Whether the EIN was able to be verified as a valid EIN with the IRS. '
+                  legal_name:
+                    type: string
+                    description: The legal name of the company
+              examples:
+                Example:
+                  value:
+                    version: 6cb95e00540706ca48d4577b3c839fbe
+                    tax_payer_type: LLP
+                    ein: '561354858'
+                    taxable_as_scorp: false
+                    filing_form: '944'
+                    ein_verified: false
+                    legal_name: Acme Corp.
       operationId: get-v1-companies-company_id_or_uuid-federal_tax_details
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
@@ -3642,7 +3518,53 @@ paths:
       summary: Update Federal Tax Details
       responses:
         '200':
-          $ref: '#/components/responses/Federal-Tax-Details-Object'
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: 'The current version of the object. See the [versioning guide](https://docs.gusto.com/docs/api/ZG9jOjUyNzM0MTc-versioning) for details using this field.'
+                  tax_payer_type:
+                    type: string
+                    description: |-
+                      What type of tax entity the company is. One of:
+                      - C-Corporation
+                      - S-Corporation
+                      - Sole proprietor
+                      - LLC
+                      - LLP
+                      - Limited partnership
+                      - Co-ownership
+                      - Association
+                      - Trusteeship
+                      - General partnership
+                      - Joint venture
+                      - Non-Profit
+                  ein:
+                    type: string
+                    description: The company's EIN
+                  taxable_as_scorp:
+                    type: boolean
+                    description: |-
+                      Whether the company is taxed as an S-Corporation. Tax payer types that may be taxed as an S-Corporation include:
+                      - S-Corporation
+                      - C-Corporation
+                      - LLC
+                  filing_form:
+                    type: string
+                    description: |-
+                      The form used by the company for federal tax filing. One of:
+                      - 941 (Quarterly federal tax return form)
+                      - 944 (Annual federal tax return form)
+                  ein_verified:
+                    type: boolean
+                    description: 'Whether the EIN was able to be verified as a valid EIN with the IRS. '
+                  legal_name:
+                    type: string
+                    description: The legal name of the company
       operationId: put-v1-companies-company_id_or_uuid-federal_tax_details
       requestBody:
         content:
@@ -3895,286 +3817,6 @@ paths:
                   version: 63859768485e218ccf8a449bb60f14ed
                   type: Check
         description: ''
-  '/v1/companies/{company_uuid}/signatories':
-    parameters:
-      - schema:
-          type: string
-        name: company_uuid
-        in: path
-        description: The ID or UUID of the company
-        required: true
-    post:
-      summary: Create a signatory
-      tags:
-        - Signatories (Beta)
-      operationId: post-v1-company-signatories
-      parameters: []
-      description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
-
-        Create a company signatory who can legally sign forms. Please note that there can only be a single primary signatory in a company. You can retrieve the current primary signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
-      responses:
-        '201':
-          $ref: '#/components/responses/Signatory-Object'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              description: ''
-              properties:
-                ssn:
-                  type: string
-                first_name:
-                  type: string
-                middle_initial:
-                  type: string
-                last_name:
-                  type: string
-                email:
-                  type: string
-                title:
-                  type: string
-                phone:
-                  type: string
-                birthday:
-                  type: string
-                home_address:
-                  type: object
-                  description: The signatory's home address
-                  properties:
-                    street_1:
-                      type: string
-                    street_2:
-                      type: string
-                    city:
-                      type: string
-                    state:
-                      type: string
-                    zip:
-                      type: string
-                  required:
-                    - street_1
-                    - city
-                    - state
-                    - zip
-              required:
-                - ssn
-                - first_name
-                - last_name
-                - email
-                - title
-                - birthday
-                - home_address
-  '/v1/companies/{company_uuid}/signatories/{uuid}':
-    parameters:
-      - schema:
-          type: string
-        name: company_uuid
-        in: path
-        description: The UUID of the company
-        required: true
-      - schema:
-          type: string
-        name: uuid
-        in: path
-        description: The UUID of the signatory
-        required: true
-    delete:
-      summary: Delete a signatory
-      tags:
-        - Signatories (Beta)
-      operationId: delete-v1-company-signatory
-      parameters: []
-      description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
-
-        Delete a company signatory. Please note that you can retrieve the signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
-      responses:
-        '204':
-          description: No Content
-  '/v1/companies/{company_id_or_uuid}/forms':
-    parameters:
-      - schema:
-          type: string
-        name: company_id_or_uuid
-        in: path
-        description: The ID or UUID of the company
-        required: true
-    get:
-      summary: Get all company forms
-      tags:
-        - Forms (Beta)
-      operationId: get-v1-company-forms
-      parameters: []
-      description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
-
-        Get a list of all company's forms
-      responses:
-        '200':
-          $ref: '#/components/responses/Form-List'
-  '/v1/forms/{id_or_uuid}':
-    parameters:
-      - schema:
-          type: string
-        name: id_or_uuid
-        in: path
-        description: The ID or UUID of the form
-        required: true
-    get:
-      summary: Get a form
-      tags:
-        - Forms (Beta)
-      operationId: get-v1-company-form
-      parameters: []
-      description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
-
-        Get a company form
-      responses:
-        '200':
-          $ref: '#/components/responses/Form-Object'
-  '/v1/forms/{id_or_uuid}/pdf':
-    parameters:
-      - schema:
-          type: string
-        name: id_or_uuid
-        in: path
-        description: The ID or UUID of the form
-        required: true
-    get:
-      summary: Get a form pdf
-      tags:
-        - Forms (Beta)
-      operationId: get-v1-company-form-pdf
-      parameters: []
-      description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
-
-        Get the link to the form PDF
-      responses:
-        '200':
-          description: Example response
-          content:
-            application/json:
-              schema:
-                title: Form PDF
-                type: object
-                properties:
-                  uuid:
-                    type: string
-                    description: the UUID of the form
-                    readOnly: true
-                  document_url:
-                    type: string
-                    description: the URL of the form
-                    readOnly: true
-              examples:
-                Example:
-                  value:
-                    uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
-                    document_url: https://app.gusto-demo.com/assets/forms/7757842065202782/original/company_direct_deposit20211007-48226-gsqo8k.pdf?1633667020
-  '/v1/forms/{id_or_uuid}/sign':
-    parameters:
-      - schema:
-          type: string
-        name: id_or_uuid
-        in: path
-        description: The ID or UUID of the form
-        required: true
-    put:
-      summary: Sign a company form
-      tags:
-        - Forms (Beta)
-      operationId: put-v1-company-form-sign
-      parameters: []
-      description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
-
-        Sign a company form
-      responses:
-        '200':
-          $ref: '#/components/responses/Form-Object'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              description: ''
-              type: object
-              properties:
-                signature_text:
-                  type: string
-                  description: The signature
-                agree:
-                  type: boolean
-                  description: whether you agree to sign electronically
-                signed_by_ip_address:
-                  type: string
-                  description: The IP address of the signatory who signed the form.
-              required:
-                - signature_text
-                - agree
-                - signed_by_ip_address
-            examples:
-              Example:
-                value:
-                  signature_text: Jane Smith
-                  agree: true
-                  signed_by_ip_address: '192.168.0.1'
-  '/v1/companies/{company_uuid}/flows':
-    parameters:
-      - schema:
-          type: string
-        name: company_uuid
-        in: path
-        description: The UUID of the company
-        required: true
-    post:
-      summary: Create a flow
-      tags:
-        - Flows (Beta)
-      operationId: post-v1-company-flows
-      parameters: []
-      description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
-
-        Generate a link to access a workflow in Gusto whitelabel UI.
-      responses:
-        '201':
-          $ref: '#/components/responses/Flow-Object'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                flow_type:
-                  type: string
-                  description: flow type
-                  enum:
-                    - company_onboarding
-                entity_uuid:
-                  type: string
-                  description: UUID of the target entity applicable to the flow. For instance, the company's UUID is used for `company_onboarding` flow.
-                entity_type:
-                  type: string
-                  description: the type of target entity applicable to the flow. For instance, `Company` is used for `company_onboarding`
-                  enum:
-                    - Company
-                expires_at:
-                  type: string
-                  description: time at which the flow is expired and no longer accessible. A default value will be used based on the flow_type if this field is not specified.
-              required:
-                - flow_type
-                - entity_uuid
-                - entity_type
-            examples:
-              Example:
-                value:
-                  flow_type: 'company_onboarding'
-                  entity_type: 'Company'
-                  entity_uuid: '89771af8-b964-472e-8064-554dfbcb56d9'
 components:
   parameters:
     pageParam:
@@ -4667,39 +4309,6 @@ components:
           effective_date: '2020-12-11'
       x-tags:
         - Compensations
-    Form:
-      title: Form
-      type: object
-      properties:
-        uuid:
-          type: string
-          description: The UUID of the form
-          readOnly: true
-        name:
-          type: string
-          description: The type identifier of the form
-          readOnly: true
-        title:
-          type: string
-          description: The title of the form
-          readOnly: true
-        description:
-          type: string
-          description: The description of the form
-          readOnly: true
-        requires_signing:
-          type: boolean
-          description: A boolean flag that indicates whether the form needs signing or not. Note that this value will change after the form is signed.
-          readOnly: true
-      x-examples:
-        Example:
-          uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
-          name: company_direct_deposit
-          title: Direct Deposit Authorization
-          description: We need you to sign paperwork to authorize us to debit and credit your bank account and file and pay your taxes.
-          requires_signing: true
-      x-tags:
-        - Forms (Beta)
     Job:
       title: Job
       type: object
@@ -5858,56 +5467,14 @@ components:
           type: string
           default: '0.00'
           description: 'The amount to be deducted, per pay period, from the employee''s pay.'
-        company_contribution:
-          type: string
-          default: '0.00'
-          description: 'The amount to be paid, per pay period, by the company. This field will not appear for tiered contribution types.'
-        employee_deduction_annual_maximum:
-          type: string
-          description: The maximum employee deduction amount per year. A null value signifies no limit.
-          nullable: true
-        company_contribution_annual_maximum:
-          type: string
-          description: The maximum company contribution amount per year. A null value signifies no limit.
-          nullable: true
-        limit_option:
-          type: string
-          description: 'Some benefits require additional information to determine their limit. For example, for an HSA benefit, the limit option should be either "Family" or "Individual". For a Dependent Care FSA benefit, the limit option should be either "Joint Filing or Single" or "Married and Filing Separately".'
-          nullable: true
         deduct_as_percentage:
           type: boolean
           default: false
           description: Whether the employee deduction amount should be treated as a percentage to be deducted from each payroll.
-        contribute_as_percentage:
-          type: boolean
-          default: false
-          description: Whether the company_contribution value should be treated as a percentage to be added to each payroll. This field will not appear for tiered contribution types.
-        catch_up:
-          type: boolean
-          default: false
-          description: Whether the employee should use a benefit’s "catch up" rate. Only Roth 401k and 401k benefits use this value for employees over 50.
-        coverage_amount:
+        employee_deduction_annual_maximum:
           type: string
-          description: 'The amount that the employee is insured for. Note: company contribution cannot be present if coverage amount is set.'
+          description: The maximum employee deduction amount per year. A null value signifies no limit.
           nullable: true
-        deduction_reduces_taxable_income:
-          type: string
-          default: unset
-          enum:
-            - unset
-            - reduces_taxable_income
-            - does_not_reduce_taxable_income
-            - null
-          description: 'Whether the employee deduction reduces taxable income or not. Only valid for Group Term Life benefits. Note: when the value is not "unset", coverage amount and coverage salary multiplier are ignored.'
-          nullable: true
-        coverage_salary_multiplier:
-          type: string
-          default: '0.00'
-          description: 'The coverage amount as a multiple of the employee’s salary. Only applicable for Group Term Life benefits. Note: cannot be set if coverage amount is also set.'
-        elective:
-          type: boolean
-          description: 'Whether the company contribution is elective (aka matching). For "tiered" contribution types, this is always true.'
-          default: false
         contribution:
           type: object
           description: An object representing the type and value of the company contribution.
@@ -5953,6 +5520,50 @@ components:
                           threshold_delta:
                             type: string
                             description: 'The step up difference between this tier''s threshold and the previous tier''s threshold. In the first tier, this is equivalent to threshold.'
+        elective:
+          type: boolean
+          description: 'Whether the company contribution is elective (aka matching). For "tiered" contribution types, this is always true.'
+          default: false
+        company_contribution_annual_maximum:
+          type: string
+          description: The maximum company contribution amount per year. A null value signifies no limit.
+          nullable: true
+        limit_option:
+          type: string
+          description: 'Some benefits require additional information to determine their limit. For example, for an HSA benefit, the limit option should be either "Family" or "Individual". For a Dependent Care FSA benefit, the limit option should be either "Joint Filing or Single" or "Married and Filing Separately".'
+          nullable: true
+        catch_up:
+          type: boolean
+          default: false
+          description: Whether the employee should use a benefit’s "catch up" rate. Only Roth 401k and 401k benefits use this value for employees over 50.
+        coverage_amount:
+          type: string
+          description: 'The amount that the employee is insured for. Note: company contribution cannot be present if coverage amount is set.'
+          nullable: true
+        deduction_reduces_taxable_income:
+          type: string
+          default: unset
+          enum:
+            - unset
+            - reduces_taxable_income
+            - does_not_reduce_taxable_income
+            - null
+          description: 'Whether the employee deduction reduces taxable income or not. Only valid for Group Term Life benefits. Note: when the value is not "unset", coverage amount and coverage salary multiplier are ignored.'
+          nullable: true
+        coverage_salary_multiplier:
+          type: string
+          default: '0.00'
+          description: 'The coverage amount as a multiple of the employee’s salary. Only applicable for Group Term Life benefits. Note: cannot be set if coverage amount is also set.'
+        company_contribution:
+          type: string
+          default: '0.00'
+          description: 'The amount to be paid, per pay period, by the company. This field will not appear for tiered contribution types.'
+          deprecated: true
+        contribute_as_percentage:
+          type: boolean
+          default: false
+          description: Whether the company_contribution value should be treated as a percentage to be added to each payroll. This field will not appear for tiered contribution types.
+          deprecated: true
     Pay-Period:
       description: The representation of a pay period.
       type: object
@@ -6486,42 +6097,6 @@ components:
         - id
         - name
         - type
-    Signatory:
-      description: The representation of a company's signatory
-      type: object
-      x-examples:
-        Example:
-          uuid: c5fdae57-5483-4529-9aae-f0edceed92d4
-          first_name: Jane
-          last_name: Smith
-          title: Signatory
-      title: Signatory
-      x-tags:
-        - Signatories (Beta)
-      properties:
-        uuid:
-          type: string
-        first_name:
-          type: string
-        last_name:
-          type: string
-        title:
-          type: string
-    Flow:
-      description: The representation of a flow in Gusto whitelabel UI.
-      type: object
-      x-examples:
-        Example:
-          url: 'https://gws-flows.gusto-demo.com/flows/lO2BHHAMCScPVV9G5WEURW0Im_nP9mGYloQgjUWbenQ'
-          expires_at: '2021-12-28 04:25:48'
-      title: Flow
-      x-tags:
-        - Flows (Beta)
-      properties:
-        url:
-          type: string
-        expires_at:
-          type: string
     Job-Applicant:
       description: The representation of a job applicant in Gusto.
       type: object
@@ -6627,7 +6202,7 @@ components:
           type: string
           description: The legal name of the company
       x-examples:
-        Example:
+        example-1:
           value:
             version: string
             tax_payer_type: string
@@ -6636,8 +6211,6 @@ components:
             filing_form: string
             ein_verified: true
             legal_name: string
-      x-tags:
-        - Federal Tax Details (Beta)
     Employee-Bank-Account:
       title: Employee-Bank-Account
       type: object
@@ -6714,6 +6287,7 @@ components:
           value:
             version: 63859768485e218ccf8a449bb60f14ed
             type: Check
+      description: ''
       properties:
         version:
           type: string
@@ -6753,8 +6327,9 @@ components:
                 description: The cents amount allocated for each payment split
                 type: integer
                 nullable: true
-      x-tags:
-        - Employee Payment Method (Beta)
+      required:
+        - version
+        - type
   securitySchemes:
     Authorization:
       type: http
@@ -7140,60 +6715,6 @@ components:
                   last_name: Labadie
                   phone: 1-565-710-7559
                   email: louie.hessel7757869450111547@zemlak.biz
-    Signatory-Object:
-      description: Example response
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Signatory'
-          examples:
-            Example:
-              value:
-                uuid: c5fdae57-5483-4529-9aae-f0edceed92d4
-                first_name: Jane
-                last_name: Smith
-                title: Signatory
-    Flow-Object:
-      description: Example response
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Flow'
-          examples:
-            Example:
-              value:
-                url: 'https://gws-flows.gusto-demo.com/flows/lO2BHHAMCScPVV9G5WEURW0Im_nP9mGYloQgjUWbenQ'
-                expires_at: '2021-12-28 04:25:48'
-    Form-Object:
-      description: Example response
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Form'
-          examples:
-            Example:
-              value:
-                uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
-                name: company_direct_deposit
-                title: Direct Deposit Authorization
-                description: We need you to sign paperwork to authorize us to debit and credit your bank account and file and pay your taxes.
-                requires_signing: true
-    Form-List:
-      description: Example response
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/Form'
-          examples:
-            Example:
-              value:
-                - uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
-                  name: company_direct_deposit
-                  title: Direct Deposit Authorization
-                  description: We need you to sign paperwork to authorize us to debit and credit your bank account and file and pay your taxes.
-                  requires_signing: true
     Job-Object:
       description: Example response
       content:
@@ -8192,16 +7713,43 @@ components:
                 company_benefit_id: 290384923980230
                 active: true
                 employee_deduction: '100.00'
-                company_contribution: '100.00'
                 employee_deduction_annual_maximum: '200.00'
                 company_contribution_annual_maximum: '200.00'
                 limit_option: null
                 deduct_as_percentage: false
-                contribute_as_percentage: false
                 catch_up: false
                 coverage_amount: null
                 deduction_reduces_taxable_income: null
                 coverage_salary_multiplier: '0.00'
+                contribution:
+                  type: amount
+                  value: '100.00'
+            Tiered example:
+              id: 0
+              version: string
+              employee_id: 0
+              company_benefit_id: 0
+              active: true
+              employee_deduction: '0.00'
+              deduct_as_percentage: false
+              employee_deduction_annual_maximum: string
+              contribution:
+                type: tiered
+                value:
+                  tiers:
+                    - rate: '5.0'
+                      threshold: '2.0'
+                      threshold_delta: '2.0'
+                    - rate: '3.0'
+                      threshold: '5.0'
+                      threshold_delta: '3.0'
+              elective: false
+              company_contribution_annual_maximum: string
+              limit_option: string
+              catch_up: false
+              coverage_amount: string
+              deduction_reduces_taxable_income: unset
+              coverage_salary_multiplier: '0.00'
     Employee-Benefit-List:
       description: Example response
       content:
@@ -8561,12 +8109,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Employee-Payment-Method'
-    Federal-Tax-Details-Object:
-      description: Example response
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Federal-Tax-Details'
   requestBodies:
     post-employee-ytd-benefit-amounts-from-different-company:
       content:

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -4500,6 +4500,39 @@ components:
           effective_date: '2020-12-11'
       x-tags:
         - Compensations
+    Form:
+      title: Form
+      type: object
+      properties:
+        uuid:
+          type: string
+          description: The UUID of the form
+          readOnly: true
+        name:
+          type: string
+          description: The type identifier of the form
+          readOnly: true
+        title:
+          type: string
+          description: The title of the form
+          readOnly: true
+        description:
+          type: string
+          description: The description of the form
+          readOnly: true
+        requires_signing:
+          type: boolean
+          description: A boolean flag that indicates whether the form needs signing or not. Note that this value will change after the form is signed.
+          readOnly: true
+      x-examples:
+        Example:
+          uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
+          name: company_direct_deposit
+          title: Direct Deposit Authorization
+          description: We need you to sign paperwork to authorize us to debit and credit your bank account and file and pay your taxes.
+          requires_signing: true
+      x-tags:
+        - Forms (Beta)
     Job:
       title: Job
       type: object
@@ -6288,6 +6321,42 @@ components:
         - id
         - name
         - type
+    Signatory:
+      description: The representation of a company's signatory
+      type: object
+      x-examples:
+        Example:
+          uuid: c5fdae57-5483-4529-9aae-f0edceed92d4
+          first_name: Jane
+          last_name: Smith
+          title: Signatory
+      title: Signatory
+      x-tags:
+        - Signatories (Beta)
+      properties:
+        uuid:
+          type: string
+        first_name:
+          type: string
+        last_name:
+          type: string
+        title:
+          type: string
+    Flow:
+      description: The representation of a flow in Gusto whitelabel UI.
+      type: object
+      x-examples:
+        Example:
+          url: 'https://gws-flows.gusto-demo.com/flows/lO2BHHAMCScPVV9G5WEURW0Im_nP9mGYloQgjUWbenQ'
+          expires_at: '2021-12-28 04:25:48'
+      title: Flow
+      x-tags:
+        - Flows (Beta)
+      properties:
+        url:
+          type: string
+        expires_at:
+          type: string
     Job-Applicant:
       description: The representation of a job applicant in Gusto.
       type: object
@@ -6393,7 +6462,7 @@ components:
           type: string
           description: The legal name of the company
       x-examples:
-        example-1:
+        Example:
           value:
             version: string
             tax_payer_type: string
@@ -6402,6 +6471,8 @@ components:
             filing_form: string
             ein_verified: true
             legal_name: string
+      x-tags:
+        - Federal Tax Details (Beta)
     Employee-Bank-Account:
       title: Employee-Bank-Account
       type: object
@@ -6478,7 +6549,6 @@ components:
           value:
             version: 63859768485e218ccf8a449bb60f14ed
             type: Check
-      description: ''
       properties:
         version:
           type: string
@@ -6518,9 +6588,8 @@ components:
                 description: The cents amount allocated for each payment split
                 type: integer
                 nullable: true
-      required:
-        - version
-        - type
+      x-tags:
+        - Employee Payment Method (Beta)
   securitySchemes:
     Authorization:
       type: http
@@ -6906,6 +6975,60 @@ components:
                   last_name: Labadie
                   phone: 1-565-710-7559
                   email: louie.hessel7757869450111547@zemlak.biz
+    Signatory-Object:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Signatory'
+          examples:
+            Example:
+              value:
+                uuid: c5fdae57-5483-4529-9aae-f0edceed92d4
+                first_name: Jane
+                last_name: Smith
+                title: Signatory
+    Flow-Object:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Flow'
+          examples:
+            Example:
+              value:
+                url: 'https://gws-flows.gusto-demo.com/flows/lO2BHHAMCScPVV9G5WEURW0Im_nP9mGYloQgjUWbenQ'
+                expires_at: '2021-12-28 04:25:48'
+    Form-Object:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Form'
+          examples:
+            Example:
+              value:
+                uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
+                name: company_direct_deposit
+                title: Direct Deposit Authorization
+                description: We need you to sign paperwork to authorize us to debit and credit your bank account and file and pay your taxes.
+                requires_signing: true
+    Form-List:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Form'
+          examples:
+            Example:
+              value:
+                - uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
+                  name: company_direct_deposit
+                  title: Direct Deposit Authorization
+                  description: We need you to sign paperwork to authorize us to debit and credit your bank account and file and pay your taxes.
+                  requires_signing: true
     Job-Object:
       description: Example response
       content:
@@ -8301,6 +8424,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Employee-Payment-Method'
+    Federal-Tax-Details-Object:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Federal-Tax-Details'
   requestBodies:
     post-employee-ytd-benefit-amounts-from-different-company:
       content:

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -3906,6 +3906,279 @@ paths:
                   version: 63859768485e218ccf8a449bb60f14ed
                   type: Check
         description: ''
+  '/v1/companies/{company_uuid}/signatories':
+    parameters:
+      - schema:
+          type: string
+        name: company_uuid
+        in: path
+        description: The ID or UUID of the company
+        required: true
+    post:
+      summary: Create a signatory
+      tags:
+        - Signatories (Beta)
+      operationId: post-v1-company-signatories
+      parameters: []
+      description: |-
+        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        Create a company signatory who can legally sign forms. Please note that there can only be a single primary signatory in a company. You can retrieve the current primary signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
+      responses:
+        '201':
+          $ref: '#/components/responses/Signatory-Object'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              description: ''
+              properties:
+                ssn:
+                  type: string
+                first_name:
+                  type: string
+                middle_initial:
+                  type: string
+                last_name:
+                  type: string
+                email:
+                  type: string
+                title:
+                  type: string
+                phone:
+                  type: string
+                birthday:
+                  type: string
+                home_address:
+                  type: object
+                  description: The signatory's home address
+                  properties:
+                    street_1:
+                      type: string
+                    street_2:
+                      type: string
+                    city:
+                      type: string
+                    state:
+                      type: string
+                    zip:
+                      type: string
+                  required:
+                    - street_1
+                    - city
+                    - state
+                    - zip
+              required:
+                - ssn
+                - first_name
+                - last_name
+                - email
+                - title
+                - birthday
+                - home_address
+  '/v1/companies/{company_uuid}/signatories/{uuid}':
+    parameters:
+      - schema:
+          type: string
+        name: company_uuid
+        in: path
+        description: The UUID of the company
+        required: true
+      - schema:
+          type: string
+        name: uuid
+        in: path
+        description: The UUID of the signatory
+        required: true
+    delete:
+      summary: Delete a signatory
+      tags:
+        - Signatories (Beta)
+      operationId: delete-v1-company-signatory
+      parameters: []
+      description: |-
+        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        Delete a company signatory. Please note that you can retrieve the signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
+      responses:
+        '204':
+          description: No Content
+  '/v1/companies/{company_id_or_uuid}/forms':
+    parameters:
+      - schema:
+          type: string
+        name: company_id_or_uuid
+        in: path
+        description: The ID or UUID of the company
+        required: true
+    get:
+      summary: Get all company forms
+      tags:
+        - Forms (Beta)
+      operationId: get-v1-company-forms
+      parameters: []
+      description: |-
+        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        Get a list of all company's forms
+      responses:
+        '200':
+          $ref: '#/components/responses/Form-List'
+  '/v1/forms/{id_or_uuid}':
+    parameters:
+      - schema:
+          type: string
+        name: id_or_uuid
+        in: path
+        description: The ID or UUID of the form
+        required: true
+    get:
+      summary: Get a form
+      tags:
+        - Forms (Beta)
+      operationId: get-v1-company-form
+      parameters: []
+      description: |-
+        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        Get a company form
+      responses:
+        '200':
+          $ref: '#/components/responses/Form-Object'
+  '/v1/forms/{id_or_uuid}/pdf':
+    parameters:
+      - schema:
+          type: string
+        name: id_or_uuid
+        in: path
+        description: The ID or UUID of the form
+        required: true
+    get:
+      summary: Get a form pdf
+      tags:
+        - Forms (Beta)
+      operationId: get-v1-company-form-pdf
+      parameters: []
+      description: |-
+        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        Get the link to the form PDF
+      responses:
+        '200':
+          description: Example response
+          content:
+            application/json:
+              schema:
+                title: Form PDF
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    description: the UUID of the form
+                    readOnly: true
+                  document_url:
+                    type: string
+                    description: the URL of the form
+                    readOnly: true
+              examples:
+                Example:
+                  value:
+                    uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
+                    document_url: https://app.gusto-demo.com/assets/forms/7757842065202782/original/company_direct_deposit20211007-48226-gsqo8k.pdf?1633667020
+  '/v1/forms/{id_or_uuid}/sign':
+    parameters:
+      - schema:
+          type: string
+        name: id_or_uuid
+        in: path
+        description: The ID or UUID of the form
+        required: true
+    put:
+      summary: Sign a company form
+      tags:
+        - Forms (Beta)
+      operationId: put-v1-company-form-sign
+      parameters: []
+      description: |-
+        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        Sign a company form
+      responses:
+        '200':
+          $ref: '#/components/responses/Form-Object'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: ''
+              type: object
+              properties:
+                signature_text:
+                  type: string
+                  description: The signature
+                agree:
+                  type: boolean
+                  description: whether you agree to sign electronically
+                signed_by_ip_address:
+                  type: string
+                  description: The IP address of the signatory who signed the form.
+              required:
+                - signature_text
+                - agree
+                - signed_by_ip_address
+            examples:
+              Example:
+                value:
+                  signature_text: Jane Smith
+                  agree: true
+                  signed_by_ip_address: '192.168.0.1'
+  '/v1/companies/{company_uuid}/flows':
+    parameters:
+      - schema:
+          type: string
+        name: company_uuid
+        in: path
+        description: The UUID of the company
+        required: true
+    post:
+      summary: Create a flow
+      tags:
+        - Flows (Beta)
+      operationId: post-v1-company-flows
+      parameters: []
+      description: |-
+        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        Generate a link to access a workflow in Gusto whitelabel UI.
+      responses:
+        '201':
+          $ref: '#/components/responses/Flow-Object'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                flow_type:
+                  type: string
+                  description: flow type
+                  enum:
+                    - company_onboarding
+                entity_uuid:
+                  type: string
+                  description: UUID of the target entity applicable to the flow. For instance, the company's UUID is used for `company_onboarding` flow.
+                entity_type:
+                  type: string
+                  description: the type of target entity applicable to the flow. For instance, `Company` is used for `company_onboarding`
+                  enum:
+                    - Company
+                expires_at:
+                  type: string
+                  description: time at which the flow is expired and no longer accessible. A default value will be used based on the flow_type if this field is not specified.
+              required:
+                - flow_type
+                - entity_uuid
+                - entity_type
+            examples:
+              Example:
+                value:
+                  flow_type: 'company_onboarding'
+                  entity_type: 'Company'
+                  entity_uuid: '89771af8-b964-472e-8064-554dfbcb56d9'
 components:
   parameters:
     pageParam:


### PR DESCRIPTION
- Move deprecated fields `company_contribution` and `contribute_as_percentage` to the bottom.
- Group together the deduction and contribution related fields
- Add the missing description text for contribution value (string).
- Change "tiered schedule" to "tiered scheme" to be more consistent.
- Update the response example and add a tiered response example.
- Minor formatting updates (i.e. using `code formatting` for enumerated types)
- Add enumerated contribution type values.