### PR TITLE
Update API README to reference the pie-hire channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ We also have a process for editing directly this repo (not recommended): https:/
 
 You need write access on both https://gusto.stoplight.io and the https://github.com/Gusto-API/api.gusto.dev repo.
 
-You can ask for access in the App Dev and Discovery channel: #pie-app-developer-and-discovery
+You can ask for access in the PIE Hire channel: #pie-hire


### PR DESCRIPTION
Took a look because of this message: https://gustohq.slack.com/archives/C01UQUSPKMX/p1637004578128300

Everything else seems fine, so just updating the channel name here.