### PR TITLE
Brian vu remove beta tags

### DIFF
--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -1856,7 +1856,7 @@ paths:
       tags:
         - Payment Configs (Beta)
       operationId: get-v1-company-payment-configs
-      parameters: [ ]
+      parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
@@ -1869,7 +1869,7 @@ paths:
       tags:
         - Payment Configs (Beta)
       operationId: put-v1-company-payment-configs
-      parameters: [ ]
+      parameters: []
       description: |-
         This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
@@ -1900,7 +1900,7 @@ paths:
               Example:
                 value:
                   fast_payment_limit: 5000
-                  payment_speed: '2-day'
+                  payment_speed: 2-day
   '/v1/companies/{company_id_or_uuid}/pay_schedules':
     parameters:
       - schema:
@@ -3342,7 +3342,7 @@ paths:
                           hours: '8.000'
   /v1/partner_managed_companies:
     post:
-      summary: Create a partner managed company (Beta)
+      summary: Create a partner managed company
       tags:
         - Companies
       responses:
@@ -3374,7 +3374,7 @@ paths:
                     company_uuid: d525dd21-ba6e-482c-be15-c2c7237f1364
       operationId: post-v1-partner-managed-companies
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         ### Overview
 
@@ -3383,7 +3383,6 @@ paths:
         * Creates a new company in Gusto.
         * Creates a new user in Gusto.
         * Makes the new user the primary payroll administrator of the new company.
-        * Sends a welcome email to the new user.
 
         Additionally, on successful creation of the company, this API will do the following:
         * Creates a link between the partner and the company.
@@ -5792,8 +5791,8 @@ components:
         Example:
           company_uuid: 423dd616-6dbc-4724-938a-403f6217a933
           partner_uuid: 556f05d0-48e0-4c47-bce5-db9aea923043
-          fast_payment_limit: 5000.0
-          payment_speed: '2-day'
+          fast_payment_limit: 5000
+          payment_speed: 2-day
       x-tags:
         - Payment Configs (Beta)
     Contractor:
@@ -9476,8 +9475,8 @@ components:
               value:
                 company_uuid: 423dd616-6dbc-4724-938a-403f6217a933
                 partner_uuid: 556f05d0-48e0-4c47-bce5-db9aea923043
-                fast_payment_limit: 5000.0
-                payment_speed: '2-day'
+                fast_payment_limit: 5000
+                payment_speed: 2-day
     Company-Bank-Account-Object:
       description: Example response
       content:

--- a/reference/Gusto-API.v1.yaml
+++ b/reference/Gusto-API.v1.yaml
@@ -150,7 +150,7 @@ paths:
       operationId: put-v1-employee-finish-onboarding
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Call this endpoint as the very last step of employee onboarding to complete their onboarding. When successful, the employee's `onboarded` attribute will be updated to true, indicating that they can be included in company's payrolls.
       responses:
@@ -192,7 +192,7 @@ paths:
       operationId: get-v1-company-onboarding-status
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get company's onboarding status. The data returned helps inform the required onboarding steps and respective completion status.
       responses:
@@ -213,7 +213,7 @@ paths:
       operationId: get-v1-company-finish-onboarding
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Use this endpoint to finalize company onboarding.
       responses:
@@ -872,7 +872,7 @@ paths:
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/perParam'
     post:
-      summary: Create a contractor payment (Beta)
+      summary: Create a contractor payment
       tags:
         - Contractor Payments
       responses:
@@ -882,7 +882,7 @@ paths:
       description: |-
         Returns an object containing individual contractor payments, within a given time period, including totals.
 
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
       parameters:
         - schema:
             type: string
@@ -949,7 +949,7 @@ paths:
 
         `scope: payrolls.read`
     delete:
-      summary: Cancel a contractor payment (Beta)
+      summary: Cancel a contractor payment
       tags:
         - Contractor Payments
       responses:
@@ -959,7 +959,7 @@ paths:
       description: |-
         Cancels and deletes a contractor payment. If the contractor payment has already started processing, the payment cannot be cancelled.
 
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
       x-internal: false
   '/v1/compensations/{compensation_id_or_uuid}':
     parameters:
@@ -1470,8 +1470,6 @@ paths:
   /v1/terms_of_service:
     get:
       summary: Get the terms of service acceptance
-      tags:
-        - Terms of Service (Beta)
       responses:
         '200':
           description: Example response
@@ -1490,9 +1488,11 @@ paths:
                     latest_terms_accepted: true
       operationId: get-v1-terms-of-service
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Returns whether the latest terms of service for Gusto Embedded Payroll has been accepted by the current user.
+      tags:
+        - Terms of Service
     post:
       summary: Accept the latest terms of service
       tags:
@@ -1515,7 +1515,7 @@ paths:
                     latest_terms_accepted: true
       operationId: post-v1-terms-of-service
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Accepts the latest terms of service for Gusto Embedded Payroll for the current user.
   '/v1/employees/{employee_uuid}/federal_taxes':
@@ -1528,26 +1528,24 @@ paths:
         description: The UUID of the employee
     get:
       summary: Get an employee's federal taxes
-      tags:
-        - Employee Federal Tax (Beta)
       responses:
         '200':
           $ref: '#/components/responses/Employee-Federal-Tax-Object'
       operationId: get-v1-employees-employee_id-federal_taxes
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get attributes relevant for an employee's federal taxes.
+      tags:
+        - Employee Federal Tax
     put:
       summary: Update an employee's federal taxes
-      tags:
-        - Employee Federal Tax (Beta)
       responses:
         '200':
           $ref: '#/components/responses/Employee-Federal-Tax-Object'
       operationId: put-v1-employees-employee_id-federal_taxes
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Update attributes relevant for an employee's federal taxes.
       requestBody:
@@ -1588,6 +1586,8 @@ paths:
                   other_income: '0.0'
                   deductions: '0.0'
                   w4_data_type: rev_2020_w4
+      tags:
+        - Employee Federal Tax
   '/v1/employees/{employee_uuid}/state_taxes':
     parameters:
       - schema:
@@ -1598,11 +1598,9 @@ paths:
         description: The UUID of the employee
     get:
       summary: Get an employee's state taxes
-      tags:
-        - Employee State Tax (Beta)
       operationId: get-v1-employees-employee_id-state_taxes
       description: |
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get attributes relevant for an employee's state taxes.
 
@@ -1612,10 +1610,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Employee-State-Taxes-List'
+      tags:
+        - Employee State Tax
     put:
       summary: Update an employee's state taxes
-      tags:
-        - Employee State Tax (Beta)
       responses:
         '200':
           $ref: '#/components/responses/Employee-State-Taxes-List'
@@ -1684,7 +1682,7 @@ paths:
                                 - string
       operationId: put-v1-employees-employee_id-state_taxes
       description: |
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Update attributes relevant for an employee's state taxes.
 
@@ -1779,6 +1777,8 @@ paths:
                             - value: '25.0'
                               valid_from: '2010-01-01'
                               valid_up_to: null
+      tags:
+        - Employee State Tax
   '/v1/employees/{employee_id_or_uuid}/home_address':
     parameters:
       - schema:
@@ -1993,25 +1993,23 @@ paths:
         required: true
     get:
       summary: Get Company Industry Selection
-      tags:
-        - Industry (Beta)
       operationId: get-v1-company-industry
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get industry selection for the company.
       responses:
         '200':
           $ref: '#/components/responses/Industry-Object'
+      tags:
+        - Industry
     put:
       summary: Update a company industry selection
-      tags:
-        - Industry (Beta)
       operationId: put-v1-company-industry
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Update the company industry selection by passing in industry classification codes: [NAICS code](https://www.naics.com), [SICS code](https://siccode.com/) and industry title. Our UI is leveraging [Middesk API](https://docs.middesk.com/reference/introduction) to determine industry classification codes.
       responses:
@@ -2046,6 +2044,8 @@ paths:
                   naics_code: '611420'
                   sic_codes:
                     - '8243'
+      tags:
+        - Industry
   '/v1/companies/{company_id_or_uuid}/pay_schedules/{pay_schedule_id_or_uuid}':
     parameters:
       - schema:
@@ -2122,21 +2122,19 @@ paths:
           $ref: '#/components/responses/Company-Bank-Account-List'
       operationId: get-v1-companies-company_id-bank-accounts
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Returns company bank accounts. Currently we only support a single default bank account per company.
       tags:
-        - Company Bank Accounts (Beta)
+        - Company Bank Accounts
     post:
       summary: Create a company bank account
       operationId: post-v1-companies-company_id-bank-accounts
-      tags:
-        - Company Bank Accounts (Beta)
       responses:
         '201':
           $ref: '#/components/responses/Company-Bank-Account-Object'
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         This endpoint creates a new company bank account.
         If a default bank account exists, the new bank account will replace it as the company's default funding method.
@@ -2171,6 +2169,8 @@ paths:
                   routing_number: '115092013'
                   account_type: Checking
                   account_number: '9775014007'
+      tags:
+        - Company Bank Accounts
   '/v1/companies/{company_id_or_uuid}/bank_accounts/{bank_account_uuid}/verify':
     parameters:
       - schema:
@@ -2188,13 +2188,11 @@ paths:
     put:
       summary: Verify a company bank account
       operationId: put-v1-companies-company_id-bank-accounts-verify
-      tags:
-        - Company Bank Accounts (Beta)
       responses:
         '200':
           $ref: '#/components/responses/Company-Bank-Account-Object'
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Verify a company bank account by confirming the two micro-deposits sent to the bank account. Note that the order of the two deposits specified in request parameters does not matter. There's a maximum of 5 verification attempts, after which we will automatically initiate a new set of micro-deposits and require the bank account to be verified with the new micro-deposits.
 
@@ -2230,6 +2228,8 @@ paths:
                 value:
                   deposit_1: 0.02
                   deposit_2: 0.42
+      tags:
+        - Company Bank Accounts
   /v1/benefits:
     get:
       summary: Get all benefits supported by Gusto
@@ -3020,7 +3020,7 @@ paths:
           name: end_date
           description: Return payrolls whose pay period is before the end date
     post:
-      summary: Create an Off-Cycle Payroll (Beta)
+      summary: Create an Off-Cycle Payroll
       tags:
         - Payrolls
       responses:
@@ -3028,7 +3028,7 @@ paths:
           $ref: '#/components/responses/Payroll-Object'
       operationId: post-v1-companies-company_id-payrolls
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Creates a new, unprocessed, off-cycle payroll.
       requestBody:
@@ -3759,7 +3759,7 @@ paths:
         in: path
         required: true
     put:
-      summary: Calculate a Payroll (Beta)
+      summary: Calculate a Payroll
       tags:
         - Payrolls
       responses:
@@ -3767,7 +3767,7 @@ paths:
           description: Accepted
       operationId: put-v1-companies-company_id-payrolls-payroll_id-calculate
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Performs calculations for taxes, benefits, and deductions for an unprocessed payroll. The calculated payroll details provide a preview of the actual values that will be used when the payroll is run.
 
@@ -3794,7 +3794,7 @@ paths:
         required: true
         description: Payroll ID or UUID
     put:
-      summary: Submit Payroll (Beta)
+      summary: Submit Payroll
       tags:
         - Payrolls
       responses:
@@ -3802,7 +3802,7 @@ paths:
           description: Accepted
       operationId: put-v1-companies-company_id-payrolls-payroll_id-submit
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Submits an unprocessed payroll to be calculated and run. This submission is asynchronous and a sucessful request responds with a 202 HTTP status. Upon success, transitions the payroll to the `processed` state.
 
@@ -3826,7 +3826,7 @@ paths:
         required: true
         description: Payroll ID or UUID
     put:
-      summary: Cancel a Payroll (Beta)
+      summary: Cancel a Payroll
       tags:
         - Payrolls
       responses:
@@ -3834,7 +3834,7 @@ paths:
           $ref: '#/components/responses/Payroll-Object'
       operationId: put-api-v1-companies-company_id-payrolls-payroll_id-cancel
       description: |
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Transitions a `processed` payroll back to the `unprocessed` state. A payroll cannot be canceled once it has entered the `funded` state.
   '/v1/companies/{company_id_or_uuid}/payroll_reversals':
@@ -3905,8 +3905,6 @@ paths:
         description: The ID of the company
     get:
       summary: Get all the admins at a company
-      tags:
-        - Admins (Beta)
       parameters:
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/perParam'
@@ -3915,19 +3913,19 @@ paths:
         '200':
           $ref: '#/components/responses/Admin-List'
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Returns a list of all the admins at a company
+      tags:
+        - Admins
     post:
       summary: Create an admin for the company.
-      tags:
-        - Admins (Beta)
       operationId: post-v1-companies-company_id-admins
       responses:
         '200':
           $ref: '#/components/responses/Admin-Object'
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Creates a new admin for a company. If the email matches an existing user, this will create an admin account for the current user. Otherwise, this will create a new user.
       requestBody:
@@ -3956,6 +3954,8 @@ paths:
                   first_name: John
                   last_name: Smith
                   email: jsmith99@gmail.com
+      tags:
+        - Admins
   '/v1/companies/{company_id_or_uuid}/federal_tax_details':
     parameters:
       - schema:
@@ -3971,14 +3971,14 @@ paths:
           $ref: '#/components/responses/Federal-Tax-Details-Object'
       operationId: get-v1-companies-company_id_or_uuid-federal_tax_details
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Fetches attributes relevant for a company's federal taxes.
       parameters: []
       security:
         - Authorization: []
       tags:
-        - Federal Tax Details (Beta)
+        - Federal Tax Details
     put:
       summary: Update Federal Tax Details
       responses:
@@ -4026,11 +4026,11 @@ paths:
                   legal_name: Acme Corp.
         description: 'Attributes related to federal tax details that can be updated via this endpoint include:'
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Updates attributes relevant for a company's federal taxes. This information is required is to onboard a company for use with Gusto Embedded Payroll.
       tags:
-        - Federal Tax Details (Beta)
+        - Federal Tax Details
   '/v1/employees/{employee_id_or_uuid}/bank_accounts':
     parameters:
       - schema:
@@ -4040,14 +4040,12 @@ paths:
         required: true
     get:
       summary: Get all employee bank accounts
-      tags:
-        - Employee Bank Accounts (Beta)
       parameters:
         - $ref: '#/components/parameters/pageParam'
         - $ref: '#/components/parameters/perParam'
       operationId: get-v1-employees-employee_id-bank_accounts
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Returns all employee bank accounts.
       responses:
@@ -4059,6 +4057,8 @@ paths:
             schema:
               type: object
               properties: {}
+      tags:
+        - Employee Bank Accounts
     post:
       summary: Create an employee bank account
       operationId: post-v1-employees-employee_id-bank_accounts
@@ -4066,7 +4066,7 @@ paths:
         '201':
           $ref: '#/components/responses/Employee-Bank-Account-Object'
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Creates an employee bank account. An employee can have multiple bank accounts. Note that creating an employee bank account will also update the employee's payment method.
       requestBody:
@@ -4099,7 +4099,7 @@ paths:
                   account_number: '5809431207'
                   account_type: Checking
       tags:
-        - Employee Bank Accounts (Beta)
+        - Employee Bank Accounts
   '/v1/employees/{employee_id_or_uuid}/bank_accounts/{bank_account_uuid}':
     parameters:
       - schema:
@@ -4119,11 +4119,11 @@ paths:
         '204':
           description: No Content
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Deletes an employee bank account. To update an employee's bank account details, delete the bank account first and create a new one.
       tags:
-        - Employee Bank Accounts (Beta)
+        - Employee Bank Accounts
   '/v1/employees/{employee_id_or_uuid}/payment_method':
     parameters:
       - schema:
@@ -4133,26 +4133,24 @@ paths:
         required: true
     get:
       summary: Get an employee's payment method
-      tags:
-        - Employee Payment Method (Beta)
       responses:
         '200':
           $ref: '#/components/responses/Employee-Payment-Method-Object'
       operationId: get-v1-employees-employee_id-payment_method
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Fetches an employee's payment method. An employee payment method describes how the payment should be split across the employee's associated bank accounts.
+      tags:
+        - Employee Payment Method
     put:
       summary: Update an employee's payment method
-      tags:
-        - Employee Payment Method (Beta)
       operationId: put-v1-employees-employee_id-payment_method
       responses:
         '200':
           $ref: '#/components/responses/Employee-Payment-Method-Object'
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Updates an employee's payment method. Note that creating an employee bank account will also update the employee's payment method.
       requestBody:
@@ -4236,6 +4234,8 @@ paths:
                   version: 63859768485e218ccf8a449bb60f14ed
                   type: Check
         description: ''
+      tags:
+        - Employee Payment Method
   '/v1/companies/{company_uuid}/signatories':
     parameters:
       - schema:
@@ -4246,12 +4246,10 @@ paths:
         required: true
     post:
       summary: Create a signatory
-      tags:
-        - Signatories (Beta)
       operationId: post-v1-company-signatories
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Create a company signatory who can legally sign forms. Please note that there can only be a single primary signatory in a company. You can retrieve the current primary signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
       responses:
@@ -4307,6 +4305,8 @@ paths:
                 - title
                 - birthday
                 - home_address
+      tags:
+        - Signatories
   '/v1/companies/{company_uuid}/signatories/{uuid}':
     parameters:
       - schema:
@@ -4323,17 +4323,17 @@ paths:
         required: true
     delete:
       summary: Delete a signatory
-      tags:
-        - Signatories (Beta)
       operationId: delete-v1-company-signatory
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Delete a company signatory. Please note that you can retrieve the signatory from `GET /v1/companies/{company_id_or_uuid}` endpoint under the `primary_signatory` property
       responses:
         '204':
           description: No Content
+      tags:
+        - Signatories
   '/v1/companies/{company_id_or_uuid}/forms':
     parameters:
       - schema:
@@ -4344,17 +4344,17 @@ paths:
         required: true
     get:
       summary: Get all company forms
-      tags:
-        - Forms (Beta)
       operationId: get-v1-company-forms
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get a list of all company's forms
       responses:
         '200':
           $ref: '#/components/responses/Form-List'
+      tags:
+        - Forms
   '/v1/forms/{id_or_uuid}':
     parameters:
       - schema:
@@ -4365,17 +4365,17 @@ paths:
         required: true
     get:
       summary: Get a company form
-      tags:
-        - Forms (Beta)
       operationId: get-v1-company-form
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get a company form
       responses:
         '200':
           $ref: '#/components/responses/Form-Object'
+      tags:
+        - Forms
   '/v1/forms/{id_or_uuid}/pdf':
     parameters:
       - schema:
@@ -4386,12 +4386,10 @@ paths:
         required: true
     get:
       summary: Get a form pdf
-      tags:
-        - Forms (Beta)
       operationId: get-v1-company-form-pdf
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get the link to the form PDF
       responses:
@@ -4416,6 +4414,8 @@ paths:
                   value:
                     uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
                     document_url: 'https://app.gusto-demo.com/assets/forms/7757842065202782/original/company_direct_deposit20211007-48226-gsqo8k.pdf?1633667020'
+      tags:
+        - Forms
   '/v1/forms/{id_or_uuid}/sign':
     parameters:
       - schema:
@@ -4426,12 +4426,10 @@ paths:
         required: true
     put:
       summary: Sign a company form
-      tags:
-        - Forms (Beta)
       operationId: put-v1-company-form-sign
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Sign a company form
       responses:
@@ -4463,6 +4461,8 @@ paths:
                   signature_text: Jane Smith
                   agree: true
                   signed_by_ip_address: 192.168.0.1
+      tags:
+        - Forms
   '/v1/employees/{employee_id_or_uuid}/forms':
     parameters:
       - schema:
@@ -4473,17 +4473,17 @@ paths:
         required: true
     get:
       summary: Get all employee forms
-      tags:
-        - Forms (Beta)
       operationId: get-v1-employee-forms
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get a list of all employee's forms
       responses:
         '200':
           $ref: '#/components/responses/Form-List'
+      tags:
+        - Forms
   '/v1/employees/{employee_id_or_uuid}/forms/{id_or_uuid}':
     parameters:
       - schema:
@@ -4500,17 +4500,17 @@ paths:
         required: true
     get:
       summary: Get an employee form
-      tags:
-        - Forms (Beta)
       operationId: get-v1-employee-form
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get an employee form
       responses:
         '200':
           $ref: '#/components/responses/Form-Object'
+      tags:
+        - Forms
   '/v1/employees/{employee_id_or_uuid}/forms/{id_or_uuid}/pdf':
     parameters:
       - schema:
@@ -4527,12 +4527,10 @@ paths:
         required: true
     get:
       summary: Get the PDF of an employee's form
-      tags:
-        - Forms (Beta)
       operationId: get-v1-employee-form-pdf
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get the link to the form PDF
       responses:
@@ -4557,6 +4555,8 @@ paths:
                   value:
                     uuid: 48cdd5ec-a4dd-4840-a424-ad79f38d8408
                     document_url: 'https://app.gusto-demo.com/assets/forms/7757842065202782/original/company_direct_deposit20211007-48226-gsqo8k.pdf?1633667020'
+      tags:
+        - Forms
   '/v1/employees/{employee_id_or_uuid}/forms/{id_or_uuid}/sign':
     parameters:
       - schema:
@@ -4573,12 +4573,10 @@ paths:
         required: true
     put:
       summary: Sign an employee form
-      tags:
-        - Forms (Beta)
       operationId: put-v1-employee-form-sign
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Sign a company form
       responses:
@@ -4610,6 +4608,8 @@ paths:
                   signature_text: Jane Smith
                   agree: true
                   signed_by_ip_address: 192.168.0.1
+      tags:
+        - Forms
   '/v1/companies/{company_uuid}/flows':
     parameters:
       - schema:
@@ -4620,12 +4620,10 @@ paths:
         required: true
     post:
       summary: Create a flow
-      tags:
-        - Flows (Beta)
       operationId: post-v1-company-flows
       parameters: []
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Generate a link to access a workflow in Gusto whitelabel UI.
       responses:
@@ -4663,6 +4661,8 @@ paths:
                   flow_type: company_onboarding
                   entity_type: Company
                   entity_uuid: 89771af8-b964-472e-8064-554dfbcb56d9
+      tags:
+        - Flows
   '/v1/payrolls/{payroll_id_or_uuid}/employees/{employee_id_or_uuid}/pay_stub':
     parameters:
       - schema:
@@ -4681,7 +4681,7 @@ paths:
         - Payrolls
       operationId: get-v1-payrolls-payroll_uuid-employees-employee_uuid-pay_stub
       description: |-
-        This endpoint is in beta and intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
+        This endpoint is intended for **[Gusto Embedded Payroll](https://gusto.com/embedded-payroll)** customers. Please [apply for early access](https://gusto-embedded-payroll.typeform.com/to/iomAQIj3?utm_source=docs) if you’d like to learn more and use it for production. Note, this endpoint will require you to enter a different agreement with Gusto.
 
         Get an employee's pay stub for the specified payroll. By default, an application/pdf response will be returned. No other content types are currently supported, but may be supported in the future.
 


### PR DESCRIPTION
removed beta tags from all endpoints except payment configs (launched 1/27/22) and removed all beta verbiage